### PR TITLE
require test_helper before the tested code

### DIFF
--- a/test/erc20/test_fake_wallet.rb
+++ b/test/erc20/test_fake_wallet.rb
@@ -13,8 +13,8 @@ require 'random-port'
 require 'shellwords'
 require 'threads'
 require 'typhoeus'
-require_relative '../../lib/erc20/fake_wallet'
 require_relative '../test__helper'
+require_relative '../../lib/erc20/fake_wallet'
 
 # Test.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)

--- a/test/erc20/test_wallet.rb
+++ b/test/erc20/test_wallet.rb
@@ -13,8 +13,8 @@ require 'random-port'
 require 'shellwords'
 require 'threads'
 require 'typhoeus'
-require_relative '../../lib/erc20/wallet'
 require_relative '../test__helper'
+require_relative '../../lib/erc20/wallet'
 
 # Test.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)


### PR DESCRIPTION
The coverage is counted as 0 again, although this is not the case.

Let's require `test__helper` before tested code