### PR TITLE
Sign the transaction before the retry loop

### DIFF
--- a/lib/erc20/wallet.rb
+++ b/lib/erc20/wallet.rb
@@ -242,6 +242,11 @@ class ERC20::Wallet
   # decrease your balance and increase the recipient's balance. This requires more
   # gas than ETH transfers since it involves executing contract code.
   #
+  # The nonce is fetched and the transaction is signed before the broadcast,
+  # outside of the retry loop. A broadcast that fails is repeated with the very
+  # same signed transaction, which the network either mines once or rejects as
+  # already known. Thus, no number of +attempts+ may pay twice.
+  #
   # @param [String] priv Private key, in hex
   # @param [String] address Public key, in hex
   # @param [Integer] amount The amount of ERC20 tokens to send
@@ -271,23 +276,21 @@ class ERC20::Wallet
     from = key.address.to_s
     tnx =
       @mutex.synchronize do
-        with_jsonrpc do |jr|
-          tx = Eth::Tx.new(
-            {
-              nonce: jr.eth_getTransactionCount(from, 'pending').to_i(16),
-              gas_price: price,
-              gas_limit: limit || gas_estimate(from, address, amount),
-              to: @contract,
-              value: 0,
-              data: to_pay_data(address, amount),
-              chain_id: @chain
-            }
-          )
-          tx.sign(key)
-          hex = "0x#{tx.hex}"
-          log_it(:debug, "Sending ERC20 transaction #{hex}")
-          jr.eth_sendRawTransaction(hex)
-        end
+        tx = Eth::Tx.new(
+          {
+            nonce: with_jsonrpc { |jr| jr.eth_getTransactionCount(from, 'pending').to_i(16) },
+            gas_price: price,
+            gas_limit: limit || gas_estimate(from, address, amount),
+            to: @contract,
+            value: 0,
+            data: to_pay_data(address, amount),
+            chain_id: @chain
+          }
+        )
+        tx.sign(key)
+        hex = "0x#{tx.hex}"
+        log_it(:debug, "Sending ERC20 transaction #{hex}")
+        with_jsonrpc { |jr| jr.eth_sendRawTransaction(hex) }
       end
     log_it(:debug, "Sent #{amount} ERC20 tokens from #{from} to #{address}: #{tnx}")
     tnx.downcase
@@ -318,22 +321,20 @@ class ERC20::Wallet
     from = key.address.to_s
     tnx =
       @mutex.synchronize do
-        with_jsonrpc do |jr|
-          tx = Eth::Tx.new(
-            {
-              chain_id: @chain,
-              nonce: jr.eth_getTransactionCount(from, 'pending').to_i(16),
-              gas_price: price,
-              gas_limit: 22_000,
-              to: address,
-              value: amount
-            }
-          )
-          tx.sign(key)
-          hex = "0x#{tx.hex}"
-          log_it(:debug, "Sending ETH transaction #{hex}")
-          jr.eth_sendRawTransaction(hex)
-        end
+        tx = Eth::Tx.new(
+          {
+            chain_id: @chain,
+            nonce: with_jsonrpc { |jr| jr.eth_getTransactionCount(from, 'pending').to_i(16) },
+            gas_price: price,
+            gas_limit: 22_000,
+            to: address,
+            value: amount
+          }
+        )
+        tx.sign(key)
+        hex = "0x#{tx.hex}"
+        log_it(:debug, "Sending ETH transaction #{hex}")
+        with_jsonrpc { |jr| jr.eth_sendRawTransaction(hex) }
       end
     log_it(:debug, "Sent #{amount} ETHs from #{from} to #{address}: #{tnx}")
     tnx.downcase

--- a/test/erc20/test_wallet.rb
+++ b/test/erc20/test_wallet.rb
@@ -102,6 +102,32 @@ class TestWallet < ERC20::Test
     end
   end
 
+  def test_broadcasts_identical_transaction_on_retry
+    WebMock.disable_net_connect!
+    sent = []
+    stub_request(:post, 'https://example.org/').to_return do |request|
+      call = JSON.parse(request.body)
+      if call['method'] == 'eth_sendRawTransaction'
+        sent.append(call['params'].first)
+        next { status: 200, body: CHALLENGE, headers: { 'Content-Type' => 'text/html' } } if sent.size == 1
+        next {
+          status: 200,
+          body: { jsonrpc: '2.0', id: call['id'], result: "0x#{'f' * 64}" }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        }
+      end
+      {
+        status: 200,
+        body: { jsonrpc: '2.0', id: call['id'], result: "0x#{sent.size}" }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      }
+    end
+    w = ERC20::Wallet.new(host: 'example.org', http_path: '/', attempts: 3, log: Loog::NULL)
+    w.define_singleton_method(:sleep) { |*| nil }
+    w.pay(JEFF, Eth::Key.new(priv: WALTER).address.to_s, 1000, limit: 60_000, price: 1000)
+    assert_equal(1, sent.uniq.size)
+  end
+
   def test_rejects_gas_limit_below_minimum
     WebMock.disable_net_connect!
     w = ERC20::Wallet.new(host: 'example.org', http_path: '/', log: Loog::NULL)


### PR DESCRIPTION
In `pay` and `eth_pay` the nonce is now read and the transaction signed before the broadcast, outside of the retry loop. A failed broadcast is repeated with the very same signed bytes.

Before this, `with_jsonrpc` replayed the entire block when the HTTP response was lost. The replay re-read the pending nonce, which by then already counted the in-flight transaction, signed a *different* transaction, and the chain happily mined both. Anyone following the `attempts: 3` advice in the README could pay twice.

The new unit test drives a broadcast that loses its first response and asserts that only one distinct raw transaction ever reaches the node.

Closes #145