### PR TITLE
Ignore transfer logs removed by a chain reorg

### DIFF
--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -4,7 +4,11 @@
 name: hadolint
 'on':
   push:
+    branches:
+      - master
   pull_request:
+    branches:
+      - master
 jobs:
   hadolint:
     timeout-minutes: 15

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'backtrace', '~>0.4', require: false
 gem 'concurrent-ruby', '~>1.2', require: false
 gem 'cucumber', '~>10.0', require: false
 gem 'donce', '~>0.2', require: false
+gem 'em-websocket', '~>0.5', require: false
 gem 'faraday', '~>2.14', require: false
 gem 'loog', '~>0.6', require: false
 gem 'minitest', '~>6.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,9 @@ GEM
       loog (~> 0.6)
       tago (~> 0.1)
     ellipsized (0.3.0)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
     erb (6.0.4)
     eth (0.5.13)
       forwardable (~> 1.3)
@@ -92,6 +95,7 @@ GEM
       rake
     forwardable (1.4.0)
     hashdiff (1.2.1)
+    http_parser.rb (0.8.1)
     json (2.19.5)
     jsonrpc-client (0.1.4)
       faraday
@@ -240,6 +244,7 @@ DEPENDENCIES
   concurrent-ruby (~> 1.2)
   cucumber (~> 10.0)
   donce (~> 0.2)
+  em-websocket (~> 0.5)
   erc20!
   faraday (~> 2.14)
   loog (~> 0.6)

--- a/lib/erc20/wallet.rb
+++ b/lib/erc20/wallet.rb
@@ -360,6 +360,16 @@ class ERC20::Wallet
   # This array is used mostly for testing. It is suggested to always provide
   # an empty array.
   #
+  # A reorganization of the chain may revert a payment that was already mined.
+  # The node then re-sends its log with the +removed+ flag set. Such an event
+  # is not yielded, since the payment never happened. In +raw+ mode the event
+  # is yielded as it arrives and the +removed+ flag must be checked by the
+  # consumer.
+  #
+  # Events are yielded with zero confirmations, the moment they arrive from the
+  # node. A payment must not be treated as settled until enough blocks are
+  # mined on top of it.
+  #
   # @param [Array<String>] addresses Addresses to monitor
   # @param [Array] active List of addresses that we are actually listening to
   # @param [Boolean] raw TRUE if you need to get JSON events as they arrive from Websockets
@@ -451,6 +461,12 @@ class ERC20::Wallet
             event = data['params']['result']
             if raw
               log_it(:debug, "New event arrived from #{event['address']}")
+              yield(event)
+            elsif event['removed']
+              log_it(
+                :debug,
+                "Payment in #{event['transactionHash']} is reverted by a reorganization of the chain, ignoring it"
+              )
             else
               event = {
                 amount: event['data'].to_i(16),
@@ -463,8 +479,8 @@ class ERC20::Wallet
                 "Payment of #{event[:amount]} tokens arrived at ##{subscription_id} " \
                 "from #{event[:from]} to #{event[:to]} in #{event[:txn]}"
               )
+              yield(event)
             end
-            yield(event)
           end
         end
       end

--- a/test/erc20/test_wallet.rb
+++ b/test/erc20/test_wallet.rb
@@ -128,6 +128,45 @@ class TestWallet < ERC20::Test
     assert_equal(1, sent.uniq.size)
   end
 
+  def transfer(amount, removed)
+    {
+      jsonrpc: '2.0',
+      method: 'eth_subscription',
+      params: {
+        subscription: '0x42',
+        result: {
+          address: ERC20::Wallet::USDT,
+          data: format('0x%064x', amount),
+          removed:,
+          topics: [
+            ERC20::Wallet::TRANSFER,
+            "0x000000000000000000000000#{Eth::Key.new(priv: JEFF).address.to_s.downcase[2..]}",
+            "0x000000000000000000000000#{Eth::Key.new(priv: WALTER).address.to_s.downcase[2..]}"
+          ],
+          transactionHash: "0x#{'e' * 64}"
+        }
+      }
+    }
+  end
+
+  def test_ignores_payment_removed_by_reorg
+    WebMock.enable_net_connect!
+    walter = Eth::Key.new(priv: WALTER).address.to_s.downcase
+    events = []
+    on_websockets([[{ jsonrpc: '2.0', id: 42, result: '0x42' }, transfer(111, true), transfer(222, false)]]) do |wallet|
+      daemon =
+        Thread.new do
+          wallet.accept([walter], [], subscription_id: 42) do |e|
+            events.append(e)
+          end
+        end
+      wait_for { !events.empty? }
+      daemon.kill
+      daemon.join(30)
+    end
+    assert_equal(222, events.first[:amount])
+  end
+
   def test_rejects_gas_limit_below_minimum
     WebMock.disable_net_connect!
     w = ERC20::Wallet.new(host: 'example.org', http_path: '/', log: Loog::NULL)

--- a/test/fake_node.rb
+++ b/test/fake_node.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'em-websocket'
+require 'json'
+require_relative '../lib/erc20/erc20'
+
+# A fake Ethereum node with Websockets, to be started by tests as
+# +ruby fake_node.rb <port> <replies.json> <received.txt>+.
+#
+# It listens to the given TCP port and answers incoming JSON messages with
+# pre-canned ones: the first message of a connection gets the first group of
+# replies, the second one gets the second group, and so on. When the groups
+# are exhausted, the node stays silent. Every message that arrives is
+# appended to the given file, one per line.
+class ERC20::FakeNode
+  def initialize(port, replies, received)
+    @port = port
+    @replies = replies
+    @received = received
+  end
+
+  def start
+    EventMachine.run do
+      EventMachine::WebSocket.run(host: '127.0.0.1', port: @port) do |ws|
+        seen = 0
+        ws.onmessage do |msg|
+          File.open(@received, 'a') { |f| f.puts(msg) }
+          (@replies[seen] || []).each do |reply|
+            # rubocop:disable Style/Send
+            ws.send(JSON.dump(reply))
+            # rubocop:enable Style/Send
+          end
+          seen += 1
+        end
+      end
+    end
+  end
+end
+
+ERC20::FakeNode.new(Integer(ARGV[0]), JSON.parse(File.read(ARGV[1])), ARGV[2]).start

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -26,6 +26,12 @@ unless SimpleCov.running
   end
 end
 
+require 'fileutils'
+require 'json'
+require 'rbconfig'
+require 'socket'
+require 'tmpdir'
+
 require 'minitest/autorun'
 require 'minitest/reporters'
 Minitest::Reporters.use!([Minitest::Reporters::SpecReporter.new])
@@ -144,6 +150,36 @@ class ERC20::Test < Minitest::Test
           Typhoeus::Request.get('https://www.google.com/generate_204', proxy:, timeout: 5).code == 204
         end
         yield(proxy)
+      end
+    end
+  end
+
+  # Run a fake Ethereum node with Websockets, in a separate process, and give
+  # a wallet connected to it. The +replies+ is a list of groups of JSON
+  # messages: the node answers the first message of the wallet with the first
+  # group, the second one with the second group, and so on. The block gets the
+  # wallet and the name of the file where all messages from the wallet land.
+  def on_websockets(replies)
+    Dir.mktmpdir do |home|
+      script = File.join(home, 'replies.json')
+      File.write(script, JSON.dump(replies))
+      received = File.join(home, 'received.txt')
+      FileUtils.touch(received)
+      RandomPort::Pool::SINGLETON.acquire do |port|
+        pid = spawn(RbConfig.ruby, File.join(__dir__, 'fake_node.rb'), port.to_s, script, received, out: File::NULL)
+        begin
+          wait_for do
+            TCPSocket.new('127.0.0.1', port).close
+            true
+          end
+          yield(
+            ERC20::Wallet.new(host: '127.0.0.1', port:, ws_path: '/', ssl: false, log: fake_loog),
+            received
+          )
+        ensure
+          Process.kill('KILL', pid)
+          Process.wait(pid)
+        end
       end
     end
   end


### PR DESCRIPTION
When a reorg drops the block that carried a transfer, the node re-sends the same log with `removed: true`. `accept` handed that to the consumer as a normal incoming payment, so anything crediting accounts from these events credits money that no longer exists on chain. Now such an event is logged and dropped. In `raw` mode it still goes through, since the consumer sees the flag itself and may want to reverse an earlier credit.

The docblock now also says out loud that events are yielded with zero confirmations, so callers know they must wait for finality before treating a payment as settled.

Reorgs can't be staged on hardhat, so the test needed a fake node: `test/fake_node.rb` is a small Websockets server, started in its own process, that answers the wallet with pre-canned messages and records what it received. `em-websocket` joins the Gemfile as a test-only dependency. The new test feeds a removed transfer followed by a good one and asserts that only the good one reaches the block.

Closes #146