### PR TITLE
Pick transfers by receiver in sum_of

### DIFF
--- a/lib/erc20/fake_wallet.rb
+++ b/lib/erc20/fake_wallet.rb
@@ -66,10 +66,13 @@ class ERC20::FakeWallet
 
   # Get ERC20 amount (in tokens) that was sent in the given transaction.
   #
-  # @param [String] _txn Hex of transaction
-  # @return [Integer] Balance, in ERC20 tokens
-  def sum_of(_txn)
-    42_000_000
+  # @param [String] txn Hex of transaction
+  # @param [String] to Public key of the receiver, in hex, starting from '0x'
+  # @return [Integer] Amount, in ERC20 tokens
+  def sum_of(txn, to: nil)
+    tokens = 42_000_000
+    @history << { method: :sum_of, txn:, to:, result: tokens }
+    tokens
   end
 
   # How many gas units are required to send an ERC20 transaction.

--- a/lib/erc20/wallet.rb
+++ b/lib/erc20/wallet.rb
@@ -155,26 +155,47 @@ class ERC20::Wallet
 
   # Get ERC20 amount (in tokens) that was sent in the given transaction.
   #
+  # One transaction may carry many transfers of the same token: batch payouts,
+  # multisend contracts, swaps, and fee splits all do that. When the +to+ is
+  # given, only the transfers to that address are counted and their sum is
+  # returned. When it is not given and the transaction carries more than one
+  # transfer, the amount is ambiguous and an error is raised.
+  #
   # @param [String] txn Hex of transaction
-  # @return [Integer] Balance, in ERC20 tokens
-  def sum_of(txn)
+  # @param [String] to Public key of the receiver, in hex, starting from '0x'
+  # @return [Integer] Amount, in ERC20 tokens
+  def sum_of(txn, to: nil)
     raise(ArgumentError, 'Transaction hash can\'t be nil') unless txn
     raise(ArgumentError, 'Transaction hash must be a String') unless txn.is_a?(String)
     raise(ArgumentError, 'Invalid format of the transaction hash') unless /^0x[0-9a-fA-F]{64}$/.match?(txn)
+    unless to.nil?
+      raise(ArgumentError, 'Address must be a String') unless to.is_a?(String)
+      raise(ArgumentError, 'Invalid format of the address') unless /^0x[0-9a-fA-F]{40}$/.match?(to)
+    end
     receipt =
       with_jsonrpc do |jr|
         jr.eth_getTransactionReceipt(txn)
       end
     raise(StandardError, "Transaction not found: #{txn}") if receipt.nil?
-    logs = receipt['logs'] || []
-    logs.each do |log|
-      next unless log['topics'] && log['topics'][0] == TRANSFER
-      next unless log['address'].downcase == @contract.downcase
-      amount = log['data'].to_i(16)
-      log_it(:debug, "Found transfer of #{amount} tokens in transaction #{txn}")
-      return amount
+    raise(StandardError, "Transaction #{txn} is reverted, its status is #{receipt['status']}") \
+      unless receipt['status'] == '0x1'
+    amounts =
+      (receipt['logs'] || []).filter_map do |log|
+        next unless log['topics'] && log['topics'][0] == TRANSFER
+        next unless log['address'].downcase == @contract.downcase
+        next unless to.nil? || log['topics'][2].to_s.downcase == "0x000000000000000000000000#{to[2..].downcase}"
+        log['data'].to_i(16)
+      end
+    raise(StandardError, "No transfer event found in transaction #{txn}") if amounts.empty?
+    if to.nil? && amounts.size > 1
+      raise(
+        StandardError,
+        "Transaction #{txn} carries #{amounts.size} transfers, tell me the receiving address to pick the right ones"
+      )
     end
-    raise(StandardError, "No transfer event found in transaction #{txn}")
+    sum = amounts.sum
+    log_it(:debug, "Found transfer of #{sum} tokens in transaction #{txn}")
+    sum
   end
 
   # How many gas units are required to send an ERC20 transaction.

--- a/test/erc20/test_wallet.rb
+++ b/test/erc20/test_wallet.rb
@@ -167,6 +167,62 @@ class TestWallet < ERC20::Test
     assert_equal(222, events.first[:amount])
   end
 
+  def receipt(transfers, status: '0x1')
+    {
+      jsonrpc: '2.0',
+      id: 42,
+      result: {
+        status:,
+        logs: transfers.map do |amount, to|
+          {
+            address: ERC20::Wallet::USDT,
+            data: format('0x%064x', amount),
+            topics: [
+              ERC20::Wallet::TRANSFER,
+              "0x000000000000000000000000#{Eth::Key.new(priv: JEFF).address.to_s.downcase[2..]}",
+              "0x000000000000000000000000#{to.downcase[2..]}"
+            ]
+          }
+        end
+      }
+    }.to_json
+  end
+
+  def test_sums_only_transfers_to_the_receiver
+    WebMock.disable_net_connect!
+    walter = Eth::Key.new(priv: WALTER).address.to_s
+    stub_request(:post, 'https://example.org/').to_return(
+      body: receipt([[100, Eth::Key.new(priv: JEFF).address.to_s], [222, walter], [333, walter]]),
+      headers: { 'Content-Type' => 'application/json' }
+    )
+    assert_equal(
+      555,
+      ERC20::Wallet.new(host: 'example.org', http_path: '/', log: Loog::NULL).sum_of("0x#{'a' * 64}", to: walter)
+    )
+  end
+
+  def test_rejects_transaction_with_many_transfers
+    WebMock.disable_net_connect!
+    stub_request(:post, 'https://example.org/').to_return(
+      body: receipt([[100, Eth::Key.new(priv: JEFF).address.to_s], [222, Eth::Key.new(priv: WALTER).address.to_s]]),
+      headers: { 'Content-Type' => 'application/json' }
+    )
+    assert_raises(StandardError) do
+      ERC20::Wallet.new(host: 'example.org', http_path: '/', log: Loog::NULL).sum_of("0x#{'a' * 64}")
+    end
+  end
+
+  def test_rejects_reverted_transaction
+    WebMock.disable_net_connect!
+    stub_request(:post, 'https://example.org/').to_return(
+      body: receipt([[100, Eth::Key.new(priv: WALTER).address.to_s]], status: '0x0'),
+      headers: { 'Content-Type' => 'application/json' }
+    )
+    assert_raises(StandardError) do
+      ERC20::Wallet.new(host: 'example.org', http_path: '/', log: Loog::NULL).sum_of("0x#{'a' * 64}")
+    end
+  end
+
   def test_rejects_gas_limit_below_minimum
     WebMock.disable_net_connect!
     w = ERC20::Wallet.new(host: 'example.org', http_path: '/', log: Loog::NULL)


### PR DESCRIPTION
`sum_of` now takes an optional `to:` and sums only the transfers that landed on that address. Without it, a transaction carrying more than one transfer is rejected as ambiguous instead of quietly returning the first log. A receipt whose status is not `0x1` is rejected as well.

Batch payouts, multisend contracts, swaps and fee splits all emit several `Transfer` events for the same token in one transaction. Returning whichever came first means a caller reconciling a payment by its hash can read an amount that belongs to a different recipient, and credit that.

`FakeWallet#sum_of` follows the same signature and now records the call in its history, like its neighbours do.

Closes #147