### PR TITLE
Fail fast when a balance answer is malformed

### DIFF
--- a/lib/erc20/wallet.rb
+++ b/lib/erc20/wallet.rb
@@ -125,6 +125,12 @@ class ERC20::Wallet
   # balance in ETH crypto. Another balance is the one kept by the ERC20 contract
   # in its own ledger in root storage. This balance is checked by this method.
   #
+  # An address that has no tokens has a balance of zero, but so does an address
+  # asked at the wrong contract or in the wrong chain: there, +eth_call+ succeeds
+  # with empty return data. A +balanceOf+ always answers with a single 32-byte
+  # word, thus anything shorter is a misconfiguration and an error is raised,
+  # instead of a zero that nobody may tell from a genuinely empty balance.
+  #
   # @param [String] address Public key, in hex, starting from '0x'
   # @return [Integer] Balance, in tokens
   def balance(address)
@@ -132,7 +138,15 @@ class ERC20::Wallet
     raise(ArgumentError, 'Address must be a String') unless address.is_a?(String)
     raise(ArgumentError, 'Invalid format of the address') unless /^0x[0-9a-fA-F]{40}$/.match?(address)
     data = "0x70a08231000000000000000000000000#{address[2..].downcase}"
-    b = with_jsonrpc { |jr| jr.eth_call({ to: @contract, data: data }, 'latest') }[2..].to_i(16)
+    hex = with_jsonrpc { |jr| jr.eth_call({ to: @contract, data: data }, 'latest') }
+    unless /^0x[0-9a-fA-F]{64}$/.match?(hex)
+      raise(
+        StandardError,
+        "The #{@contract} contract in chain #{@chain} answered #{hex.inspect} instead of " \
+        'a 32-byte word, it may not be an ERC20 contract at all'
+      )
+    end
+    b = hex[2..].to_i(16)
     log_it(:debug, "The balance of #{address} is #{b} ERC20 tokens")
     b
   end
@@ -148,7 +162,11 @@ class ERC20::Wallet
     raise(ArgumentError, 'Address can\'t be nil') unless address
     raise(ArgumentError, 'Address must be a String') unless address.is_a?(String)
     raise(ArgumentError, 'Invalid format of the address') unless /^0x[0-9a-fA-F]{40}$/.match?(address)
-    b = with_jsonrpc { |jr| jr.eth_getBalance(address, 'latest') }[2..].to_i(16)
+    hex = with_jsonrpc { |jr| jr.eth_getBalance(address, 'latest') }
+    unless /^0x[0-9a-fA-F]+$/.match?(hex)
+      raise(StandardError, "The node answered #{hex.inspect} instead of a hex quantity, for the balance of #{address}")
+    end
+    b = hex[2..].to_i(16)
     log_it(:debug, "The balance of #{address} is #{b} ETHs")
     b
   end

--- a/test/erc20/test_wallet.rb
+++ b/test/erc20/test_wallet.rb
@@ -29,7 +29,7 @@ class TestWallet < ERC20::Test
   def test_logs_to_stdout
     WebMock.disable_net_connect!
     stub_request(:post, 'https://example.org/').to_return(
-      body: { jsonrpc: '2.0', id: 42, result: '0x1F1F1F' }.to_json,
+      body: { jsonrpc: '2.0', id: 42, result: format('0x%064x', 0x1F1F1F) }.to_json,
       headers: { 'Content-Type' => 'application/json' }
     )
     ERC20::Wallet.new(
@@ -47,7 +47,43 @@ class TestWallet < ERC20::Test
 
   CHALLENGE = '<!DOCTYPE html><html><head><title>Just a moment...</title></head></html>'
 
-  GOOD_JSON = { jsonrpc: '2.0', id: 42, result: '0x1F1F1F' }.to_json
+  GOOD_JSON = { jsonrpc: '2.0', id: 42, result: format('0x%064x', 0x1F1F1F) }.to_json
+
+  def test_rejects_empty_result_of_balance
+    WebMock.disable_net_connect!
+    stub_request(:post, 'https://example.org/').to_return(
+      body: { jsonrpc: '2.0', id: 42, result: '0x' }.to_json,
+      headers: { 'Content-Type' => 'application/json' }
+    )
+    w = ERC20::Wallet.new(host: 'example.org', http_path: '/', log: Loog::NULL)
+    assert_raises(StandardError) do
+      w.balance(Eth::Key.new(priv: JEFF).address.to_s)
+    end
+  end
+
+  def test_rejects_empty_result_of_eth_balance
+    WebMock.disable_net_connect!
+    stub_request(:post, 'https://example.org/').to_return(
+      body: { jsonrpc: '2.0', id: 42, result: '0x' }.to_json,
+      headers: { 'Content-Type' => 'application/json' }
+    )
+    w = ERC20::Wallet.new(host: 'example.org', http_path: '/', log: Loog::NULL)
+    assert_raises(StandardError) do
+      w.eth_balance(Eth::Key.new(priv: JEFF).address.to_s)
+    end
+  end
+
+  def test_rejects_truncated_result_of_balance
+    WebMock.disable_net_connect!
+    stub_request(:post, 'https://example.org/').to_return(
+      body: { jsonrpc: '2.0', id: 42, result: '0x1F1F1F' }.to_json,
+      headers: { 'Content-Type' => 'application/json' }
+    )
+    w = ERC20::Wallet.new(host: 'example.org', http_path: '/', log: Loog::NULL)
+    assert_raises(StandardError) do
+      w.balance(Eth::Key.new(priv: JEFF).address.to_s)
+    end
+  end
 
   def test_retries_on_transient_non_json_response
     WebMock.disable_net_connect!

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -125,7 +125,10 @@ class ERC20::Test < Minitest::Test
         ws_path: "/#{env('GETBLOCK_SEPOILA_KEY')}"
       }
     ].map do |server|
-      ERC20::Wallet.new(host: server[:host], http_path: server[:http_path], ws_path: server[:ws_path], log: fake_loog)
+      ERC20::Wallet.new(
+        contract: '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238', chain: 11_155_111,
+        host: server[:host], http_path: server[:http_path], ws_path: server[:ws_path], log: fake_loog
+      )
     end.sample
   end
 


### PR DESCRIPTION
Both `balance` and `eth_balance` used to pipe whatever the node returned straight into `[2..].to_i(16)`. For `"0x"` that quietly yields `0`, so a wallet pointed at an address that holds no contract — wrong contract, wrong chain, an EOA — reported an empty account instead of complaining. Now the shape of the answer is checked first: `balanceOf` must come back as a full 32-byte word, `eth_getBalance` as a hex quantity, and anything else raises with the contract and chain in the message.

The check immediately caught a test that was living off the bug: `testnet` built a wallet with the mainnet USDT contract and chain 1, then asked Sepolia for a balance and asserted zero. That helper now points at the USDC contract that actually exists on Sepolia, with chain 11155111.

Worth knowing: the live mainnet tests are erroring for me right now with `-32603 Internal error` from Infura on every call, including on `master`. That is the same flake that reddened #161, unrelated to this change — happy to file a separate issue about making those tests skip instead of erroring when the provider misbehaves.

Closes #148