### PR TITLE
Skip live tests when the node is in trouble

### DIFF
--- a/test/erc20/test_wallet.rb
+++ b/test/erc20/test_wallet.rb
@@ -40,9 +40,11 @@ class TestWallet < ERC20::Test
 
   def test_checks_balance_on_testnet
     WebMock.enable_net_connect!
-    b = testnet.balance(Eth::Key.new(priv: JEFF).address.to_s)
-    refute_nil(b)
-    assert_predicate(b, :zero?)
+    live do
+      b = testnet.balance(Eth::Key.new(priv: JEFF).address.to_s)
+      refute_nil(b)
+      assert_predicate(b, :zero?)
+    end
   end
 
   CHALLENGE = '<!DOCTYPE html><html><head><title>Just a moment...</title></head></html>'

--- a/test/erc20/test_wallet_live.rb
+++ b/test/erc20/test_wallet_live.rb
@@ -26,31 +26,39 @@ class TestWalletLive < ERC20::Test
 
   def test_checks_balance_on_mainnet
     WebMock.enable_net_connect!
-    b = mainnet.balance(STABLE)
-    refute_nil(b)
-    assert_equal(8_000_000, b)
+    live do
+      b = mainnet.balance(STABLE)
+      refute_nil(b)
+      assert_equal(8_000_000, b)
+    end
   end
 
   def test_checks_eth_balance_on_mainnet
     WebMock.enable_net_connect!
-    b = mainnet.eth_balance(STABLE)
-    refute_nil(b)
-    assert_equal(4_200_000_000_000_000, b)
+    live do
+      b = mainnet.eth_balance(STABLE)
+      refute_nil(b)
+      assert_equal(4_200_000_000_000_000, b)
+    end
   end
 
   def test_checks_balance_of_absent_address
     WebMock.enable_net_connect!
-    b = mainnet.balance('0xEB2fE8872A6f1eDb70a2632Effffffffffffffff')
-    refute_nil(b)
-    assert_equal(0, b)
+    live do
+      b = mainnet.balance('0xEB2fE8872A6f1eDb70a2632Effffffffffffffff')
+      refute_nil(b)
+      assert_equal(0, b)
+    end
   end
 
   def test_checks_gas_estimate_on_mainnet
     WebMock.enable_net_connect!
-    b = mainnet.gas_estimate(STABLE, '0x7232148927F8a580053792f44D4d5FFFFFFFFFFF', 44_000)
-    refute_nil(b)
-    assert_predicate(b, :positive?)
-    assert_operator(b, :>, 1000)
+    live do
+      b = mainnet.gas_estimate(STABLE, '0x7232148927F8a580053792f44D4d5FFFFFFFFFFF', 44_000)
+      refute_nil(b)
+      assert_predicate(b, :positive?)
+      assert_operator(b, :>, 1000)
+    end
   end
 
   def test_fails_with_invalid_infura_key
@@ -67,32 +75,41 @@ class TestWalletLive < ERC20::Test
 
   def test_checks_balance_on_polygon
     WebMock.enable_net_connect!
-    b = ERC20::Wallet.new(
-      contract: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F',
-      host: 'polygon-mainnet.infura.io',
-      http_path: "/v3/#{env('INFURA_KEY')}",
-      log: fake_loog
-    ).balance(STABLE)
-    refute_nil(b)
-    assert_predicate(b, :zero?)
+    live do
+      b = ERC20::Wallet.new(
+        contract: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F',
+        host: 'polygon-mainnet.infura.io',
+        http_path: "/v3/#{env('INFURA_KEY')}",
+        log: fake_loog
+      ).balance(STABLE)
+      refute_nil(b)
+      assert_predicate(b, :zero?)
+    end
   end
 
   def test_accepts_payments_on_mainnet
     WebMock.enable_net_connect!
     active = []
-    failed = false
+    trouble = nil
     net = mainnet
     daemon =
       Thread.new do
         net.accept([STABLE], active) { |_| nil }
       rescue StandardError => e
-        failed = true
+        trouble = e
         fake_loog.error(Backtrace.new(e))
       end
-    wait_for { !active.empty? }
-    daemon.kill
-    daemon.join(30)
-    refute(failed)
+    live do
+      seen = []
+      wait_for do
+        seen = active.to_a.dup
+        !seen.empty? || !trouble.nil?
+      end
+      daemon.kill
+      daemon.join(30)
+      raise(trouble) unless trouble.nil?
+      refute_empty(seen)
+    end
   end
 
   def test_pings_google_via_proxy
@@ -105,13 +122,15 @@ class TestWalletLive < ERC20::Test
   def test_checks_balance_via_proxy_on_mainnet
     WebMock.enable_net_connect!
     via_proxy do |proxy|
-      assert_equal(
-        8_000_000,
-        ERC20::Wallet.new(
-          host: 'mainnet.infura.io', http_path: "/v3/#{env('INFURA_KEY')}", proxy:,
-          log: fake_loog
-        ).balance(STABLE)
-      )
+      live do
+        assert_equal(
+          8_000_000,
+          ERC20::Wallet.new(
+            host: 'mainnet.infura.io', http_path: "/v3/#{env('INFURA_KEY')}", proxy:,
+            log: fake_loog
+          ).balance(STABLE)
+        )
+      end
     end
   end
 

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -26,8 +26,10 @@ unless SimpleCov.running
   end
 end
 
+require 'faraday'
 require 'fileutils'
 require 'json'
+require 'jsonrpc/client'
 require 'rbconfig'
 require 'socket'
 require 'tmpdir'
@@ -93,6 +95,21 @@ class ERC20::Test < Minitest::Test
     skip("The #{var} environment variable is not set") if key.nil?
     skip("The #{var} environment variable is empty") if key.empty?
     key
+  end
+
+  # Run a block that talks to a public Ethereum node and skip the test when the
+  # node is in trouble: down, throttling, or unreachable. An outage of a
+  # third-party provider is not a defect of this gem and must not paint the
+  # build red. Genuine RPC errors and broken assertions still do.
+  def live
+    yield
+  rescue JSONRPC::Error::ServerError => e
+    raise unless [-32_603, -32_005, -32_002].include?(e.code)
+    skip("The node is in trouble, thus skipping: #{e.message}")
+  rescue JSONRPC::Error::InvalidJSON, JSONRPC::Error::InvalidResponse => e
+    skip("The node answered with garbage, thus skipping: #{e.message}")
+  rescue Faraday::ConnectionFailed, Faraday::SSLError, Faraday::TimeoutError => e
+    skip("The node is unreachable, thus skipping: #{e.message}")
   end
 
   def mainnet


### PR DESCRIPTION
Adds a `live` wrapper to `ERC20::Test` and puts the bodies of the tests that talk to public Ethereum nodes inside it. When the node answers with `-32603`, `-32005`, or `-32002`, hands back garbage, or cannot be reached at all, the test skips. Anything else — a real JSON-RPC error such as a reverted call, or a broken assertion — still fails the build, same as before.

Infura has been answering `-32603 Internal error` to every request for the past hour, and `test_checks_balance_via_proxy_on_mainnet` is the one mainnet test that cannot dodge it, since it hard-codes the host instead of going through the `mainnet` helper. That single outage turned master and both open pull requests red, and minitest-retry burned three retries on it each run. A provider having a bad hour says nothing about this gem.

Two things a reviewer may want to look at. The `accept` test now re-raises whatever its listening thread caught, so an outage there gets classified as well, and it snapshots the address list with a copy — `Array#to_a` hands back the very same array that `accept` clears on each re-subscribe, which made the assertion flaky the moment I moved it. `test_pings_google_via_proxy` is left alone: Typhoeus reports a failure as a zero status code rather than an exception, so there is nothing for `live` to catch.

Closes #163