### PR TITLE
Try every RPC endpoint before giving up

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ w = ERC20::Wallet.new(
   host: 'mainnet.infura.io',
   http_path: '/v3/<your-infura-key>',
   ws_path: '/ws/v3/<your-infura-key>',
-  attempts: 3, # retry failed HTTP RPC calls up to 3 times, with backoff
+  attempts: 3, # try every endpoint up to 3 times, with backoff
   fallbacks: ['https://eth.drpc.org'], # alternative RPC endpoints to try
   log: $stdout
 )

--- a/bin/erc20
+++ b/bin/erc20
@@ -43,7 +43,7 @@ class Bin < Thor
   class_option :proxy, type: :string,
     desc: 'HTTP/S proxy for all requests, e.g. "localhost:3128"'
   class_option :attempts, type: :numeric, default: 1,
-    desc: 'How many times should we try before failing'
+    desc: 'How many times should we try every endpoint before failing'
   class_option :fallbacks, type: :array,
     default: ['https://ethereum.publicnode.com', 'https://eth.drpc.org', 'https://rpc.ankr.com/eth'],
     desc: 'Fallback HTTP RPC endpoint URLs to try when the primary host fails'

--- a/lib/erc20/wallet.rb
+++ b/lib/erc20/wallet.rb
@@ -72,7 +72,7 @@ class ERC20::Wallet
   # @param [String] ws_path The path in the connection URL, for Websockets
   # @param [Boolean] ssl Should we use SSL (for https and wss)
   # @param [String] proxy The URL of the proxy to use
-  # @param [Integer] attempts How many times to retry a failed HTTP RPC call before giving up
+  # @param [Integer] attempts How many times to try every HTTP RPC endpoint before giving up
   # @param [Array<String>] fallbacks Alternative HTTP RPC endpoint URLs to try when the primary one fails
   # @param [Object] log The destination for logs
   def initialize(
@@ -578,17 +578,18 @@ class ERC20::Wallet
         end
     end
     endpoints = [url.to_s] + @fallbacks
-    attempt = 0
+    budget = @attempts * endpoints.size
+    tried = 0
     begin
-      attempt += 1
-      u = URI.parse(endpoints[(attempt - 1) % endpoints.size])
+      u = URI.parse(endpoints[tried % endpoints.size])
+      tried += 1
       elapsed(@log, good: "Talked to #{u.host}:#{u.port}") do
         yield(JSONRPC::Client.new(u.to_s, opts))
       end
     rescue StandardError => e
-      raise if attempt >= @attempts
-      pause = 2**(attempt - 1)
-      log_it(:debug, "Attempt #{attempt}/#{@attempts} to #{u.host} failed (#{e.class}), retrying in #{pause}s")
+      raise if tried >= budget
+      pause = (tried % endpoints.size).zero? ? 2**((tried / endpoints.size) - 1) : 0
+      log_it(:debug, "Attempt #{tried}/#{budget} to #{u.host} failed (#{e.class}), retrying in #{pause}s")
       sleep(pause)
       retry
     end

--- a/test/erc20/test_wallet.rb
+++ b/test/erc20/test_wallet.rb
@@ -126,6 +126,63 @@ class TestWallet < ERC20::Test
     assert_equal(0x1F1F1F, w.balance(Eth::Key.new(priv: JEFF).address.to_s))
   end
 
+  def test_falls_back_with_a_single_attempt
+    WebMock.disable_net_connect!
+    stub_request(:post, 'https://example.org/').to_return(
+      status: 200, body: CHALLENGE, headers: { 'Content-Type' => 'text/html' }
+    )
+    stub_request(:post, 'https://backup.example.org/').to_return(
+      status: 200, body: GOOD_JSON, headers: { 'Content-Type' => 'application/json' }
+    )
+    w = ERC20::Wallet.new(
+      host: 'example.org', http_path: '/',
+      fallbacks: ['https://backup.example.org/'], log: Loog::NULL
+    )
+    w.define_singleton_method(:sleep) { |*| nil }
+    assert_equal(0x1F1F1F, w.balance(Eth::Key.new(priv: JEFF).address.to_s))
+  end
+
+  def test_reaches_the_last_fallback
+    WebMock.disable_net_connect!
+    stub_request(:post, 'https://example.org/').to_return(
+      status: 200, body: CHALLENGE, headers: { 'Content-Type' => 'text/html' }
+    )
+    stub_request(:post, 'https://first.example.org/').to_return(
+      status: 200, body: CHALLENGE, headers: { 'Content-Type' => 'text/html' }
+    )
+    stub_request(:post, 'https://second.example.org/').to_return(
+      status: 200, body: GOOD_JSON, headers: { 'Content-Type' => 'application/json' }
+    )
+    w = ERC20::Wallet.new(
+      host: 'example.org', http_path: '/',
+      fallbacks: ['https://first.example.org/', 'https://second.example.org/'], log: Loog::NULL
+    )
+    w.define_singleton_method(:sleep) { |*| nil }
+    assert_equal(0x1F1F1F, w.balance(Eth::Key.new(priv: JEFF).address.to_s))
+  end
+
+  def test_spends_all_attempts_on_every_endpoint
+    WebMock.disable_net_connect!
+    seen = []
+    ['https://example.org/', 'https://backup.example.org/'].each do |endpoint|
+      stub_request(:post, endpoint).to_return do |_|
+        seen.append(endpoint)
+        { status: 200, body: CHALLENGE, headers: { 'Content-Type' => 'text/html' } }
+      end
+    end
+    w = ERC20::Wallet.new(
+      host: 'example.org', http_path: '/',
+      fallbacks: ['https://backup.example.org/'], attempts: 3, log: Loog::NULL
+    )
+    w.define_singleton_method(:sleep) { |*| nil }
+    begin
+      w.balance(Eth::Key.new(priv: JEFF).address.to_s)
+    rescue StandardError => e
+      Loog::NULL.debug(e.message)
+    end
+    assert_equal(6, seen.size)
+  end
+
   def test_rejects_non_array_fallbacks
     WebMock.disable_net_connect!
     assert_raises(ArgumentError) do


### PR DESCRIPTION
The endpoint to talk to was picked by the retry counter, and that counter was gated by `attempts`. With the default `attempts: 1` the first failure re-raised right away, so no fallback was ever tried — the CLI ships three of them by default and none of them could ever help. Even with a larger `attempts`, the number of endpoints tried equalled `attempts`, so the last fallback stayed unreachable unless you set `attempts` above the number of fallbacks.

Now every failure rotates to the next endpoint and the give-up threshold is `attempts * endpoints`, so each endpoint gets its full share of tries and the whole list is always covered. The exponential pause now applies only between full rounds — switching to a different server is not something worth waiting for.

Three unit tests cover it: a fallback used with the default single attempt, the last of two fallbacks reached, and the budget spent evenly across endpoints. The docs in `README.md` and `bin/erc20` now say what `attempts` counts.

Closes #149