### PR TITLE
Reject amounts that do not fit into uint256

### DIFF
--- a/lib/erc20/wallet.rb
+++ b/lib/erc20/wallet.rb
@@ -61,6 +61,9 @@ class ERC20::Wallet
   USDT = '0xdac17f958d2ee523a2206206994597c13d831ec7'
   TRANSFER = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 
+  MAX_AMOUNT = (2**256) - 1
+  private_constant :MAX_AMOUNT
+
   attr_reader :host, :port, :ssl, :chain, :contract, :ws_path, :http_path
 
   # Constructor.
@@ -232,6 +235,7 @@ class ERC20::Wallet
     raise(ArgumentError, 'Amount can\'t be nil') unless amount
     raise(ArgumentError, "Amount (#{amount}) must be an Integer") unless amount.is_a?(Integer)
     raise(ArgumentError, "Amount (#{amount}) must be a positive Integer") unless amount.positive?
+    raise(ArgumentError, "Amount (#{amount}) must fit into uint256") if amount > MAX_AMOUNT
     gas =
       with_jsonrpc do |jr|
         jr.eth_estimateGas({ from:, to: @contract, data: to_pay_data(to, amount) }, 'latest').to_i(16)
@@ -302,6 +306,7 @@ class ERC20::Wallet
     raise(ArgumentError, 'Amount can\'t be nil') unless amount
     raise(ArgumentError, "Amount (#{amount}) must be an Integer") unless amount.is_a?(Integer)
     raise(ArgumentError, "Amount (#{amount}) must be a positive Integer") unless amount.positive?
+    raise(ArgumentError, "Amount (#{amount}) must fit into uint256") if amount > MAX_AMOUNT
     if limit
       raise(ArgumentError, 'Gas limit must be an Integer') unless limit.is_a?(Integer)
       raise(ArgumentError, "Gas limit #{limit} is below #{Eth::Tx::DEFAULT_GAS_LIMIT}") if limit < Eth::Tx::DEFAULT_GAS_LIMIT
@@ -596,9 +601,7 @@ class ERC20::Wallet
   end
 
   def to_pay_data(address, amount)
-    to_clean = address.downcase.sub(/^0x/, '')
-    amt_hex = amount.to_s(16)
-    "0xa9059cbb#{('0' * (64 - to_clean.size)) + to_clean}#{('0' * (64 - amt_hex.size)) + amt_hex}"
+    "0xa9059cbb#{format('%064x', address.to_i(16))}#{format('%064x', amount)}"
   end
 
   def log_it(method, msg)

--- a/test/erc20/test_wallet.rb
+++ b/test/erc20/test_wallet.rb
@@ -318,6 +318,43 @@ class TestWallet < ERC20::Test
     end
   end
 
+  def test_rejects_amount_above_the_word_maximum
+    WebMock.disable_net_connect!
+    w = ERC20::Wallet.new(host: 'example.org', http_path: '/', log: Loog::NULL)
+    assert_raises(ArgumentError) do
+      w.pay(JEFF, Eth::Key.new(priv: WALTER).address.to_s, 2**256, limit: 60_000, price: 1000)
+    end
+  end
+
+  def test_explains_why_a_huge_amount_is_rejected
+    WebMock.disable_net_connect!
+    w = ERC20::Wallet.new(host: 'example.org', http_path: '/', log: Loog::NULL)
+    assert_match(
+      /must fit into uint256/,
+      assert_raises(ArgumentError) do
+        w.gas_estimate(Eth::Key.new(priv: JEFF).address.to_s, Eth::Key.new(priv: WALTER).address.to_s, 2**256)
+      end.message
+    )
+  end
+
+  def test_encodes_the_largest_amount_in_a_single_word
+    WebMock.disable_net_connect!
+    data = nil
+    stub_request(:post, 'https://example.org/').to_return do |request|
+      data = JSON.parse(request.body)['params'].first['data']
+      {
+        status: 200,
+        body: { jsonrpc: '2.0', id: 42, result: '0x5208' }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      }
+    end
+    walter = Eth::Key.new(priv: WALTER).address.to_s
+    ERC20::Wallet.new(host: 'example.org', http_path: '/', log: Loog::NULL).gas_estimate(
+      Eth::Key.new(priv: JEFF).address.to_s, walter, (2**256) - 1
+    )
+    assert_equal("0xa9059cbb000000000000000000000000#{walter.downcase[2..]}#{'f' * 64}", data)
+  end
+
   def test_rejects_gas_limit_below_minimum
     WebMock.disable_net_connect!
     w = ERC20::Wallet.new(host: 'example.org', http_path: '/', log: Loog::NULL)


### PR DESCRIPTION
`pay` and `gas_estimate` check that the amount is a positive `Integer` but never that it fits into the ABI `uint256` word. Both now reject anything above `2**256 - 1` right where the rest of the arguments are checked. While in there, `to_pay_data` builds the two words with `format('%064x', ...)` instead of counting zeroes by hand, so the width of a word is stated once and the padding cannot go negative.

One correction to the issue: an over-range amount was not silently misencoded. `'0' * -1` raises in Ruby, so the call died anyway — but with a bare `ArgumentError: negative argument` from a private method, which tells the caller nothing about which argument was wrong or why. That is what this fixes, and the tests pin the message, not just the class.

The `eth_pay` gas-limit remark at the end of the issue is a different defect and is untouched here — happy to look at it separately if you want it filed.

Closes #150