### PR TITLE
Treat a JSON-RPC error reply as a failed subscription

### DIFF
--- a/lib/erc20/wallet.rb
+++ b/lib/erc20/wallet.rb
@@ -404,6 +404,10 @@ class ERC20::Wallet
   # and it is rebuilt on every confirmation. This array is used mostly for
   # testing. It is suggested to always provide an empty array.
   #
+  # When the node answers a subscribe request with an error, the addresses stay
+  # out of +active+, the error goes to the log, and the next subscribe attempt
+  # happens +delay+ seconds later.
+  #
   # A reorganization of the chain may revert a payment that was already mined.
   # The node then re-sends its log with the +removed+ flag set. Such an event
   # is not yielded, since the payment never happened. In +raw+ mode the event
@@ -505,7 +509,10 @@ class ERC20::Wallet
       safe do
         verbose do
           data = to_json(msg)
-          if data['id'] == subscription_id
+          if data['error']
+            active.clear if data['id'] == subscription_id
+            log_it(:error, "Request ##{data['id']} was rejected by #{log_url}: #{data['error']}")
+          elsif data['id'] == subscription_id
             subscription = data['result']
             active.clear
             wanted&.each { |a| active.append(a) }
@@ -563,7 +570,8 @@ class ERC20::Wallet
 
   def to_json(msg)
     JSON.parse(msg.data)
-  rescue StandardError
+  rescue StandardError => e
+    log_it(:error, "Failed to parse a frame of #{msg.data.to_s.length} bytes (#{e.message}): #{msg.data}")
     {}
   end
 

--- a/test/erc20/test_wallet.rb
+++ b/test/erc20/test_wallet.rb
@@ -313,6 +313,58 @@ class TestWallet < ERC20::Test
     assert_equal(2, subscribes)
   end
 
+  def rejection
+    [[{ jsonrpc: '2.0', id: 42, error: { code: -32_602, message: 'too many topics' } }]]
+  end
+
+  def test_ignores_a_rejected_subscription
+    WebMock.enable_net_connect!
+    seen = nil
+    on_websockets(rejection) do |wallet|
+      active = []
+      daemon =
+        Thread.new do
+          wallet.accept([Eth::Key.new(priv: JEFF).address.to_s.downcase], active, subscription_id: 42) { |_| nil }
+        end
+      sleep(3)
+      seen = active.to_a.dup
+      daemon.kill
+      daemon.join(30)
+    end
+    assert_empty(seen, 'Addresses cannot be active when the node rejects the subscription')
+  end
+
+  def test_retries_a_rejected_subscription
+    WebMock.enable_net_connect!
+    subscribes = 0
+    on_websockets(rejection) do |wallet, received|
+      daemon =
+        Thread.new do
+          wallet.accept([Eth::Key.new(priv: WALTER).address.to_s.downcase], [], subscription_id: 42) { |_| nil }
+        end
+      sleep(4)
+      daemon.kill
+      daemon.join(30)
+      subscribes = File.readlines(received).count { |line| JSON.parse(line)['method'] == 'eth_subscribe' }
+    end
+    assert_operator(subscribes, :>, 1, 'A rejected subscription cannot be the last attempt')
+  end
+
+  def test_complains_about_a_corrupt_frame
+    WebMock.enable_net_connect!
+    buf = Loog::Buffer.new
+    on_websockets([['}not json{']], log: buf) do |wallet|
+      daemon =
+        Thread.new do
+          wallet.accept([Eth::Key.new(priv: JEFF).address.to_s.downcase], [], subscription_id: 42) { |_| nil }
+        end
+      wait_for(10) { buf.to_s.include?('not json') }
+      daemon.kill
+      daemon.join(30)
+    end
+    assert_match(/Failed to parse/, buf.to_s, 'A corrupt frame cannot be discarded silently')
+  end
+
   def receipt(transfers, status: '0x1')
     {
       jsonrpc: '2.0',

--- a/test/fake_node.rb
+++ b/test/fake_node.rb
@@ -15,6 +15,9 @@ require_relative '../lib/erc20/erc20'
 # replies, the second one gets the second group, and so on. When the groups
 # are exhausted, the node stays silent. Every message that arrives is
 # appended to the given file, one per line.
+#
+# A reply that is a String travels to the client verbatim, which is how a
+# test emits a frame that is not valid JSON.
 class ERC20::FakeNode
   def initialize(port, replies, received)
     @port = port
@@ -30,7 +33,7 @@ class ERC20::FakeNode
           File.open(@received, 'a') { |f| f.puts(msg) }
           (@replies[seen] || []).each do |reply|
             # rubocop:disable Style/Send
-            ws.send(JSON.dump(reply))
+            ws.send(reply.is_a?(String) ? reply : JSON.dump(reply))
             # rubocop:enable Style/Send
           end
           seen += 1

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -179,7 +179,7 @@ class ERC20::Test < Minitest::Test
   # messages: the node answers the first message of the wallet with the first
   # group, the second one with the second group, and so on. The block gets the
   # wallet and the name of the file where all messages from the wallet land.
-  def on_websockets(replies)
+  def on_websockets(replies, log: fake_loog)
     Dir.mktmpdir do |home|
       script = File.join(home, 'replies.json')
       File.write(script, JSON.dump(replies))
@@ -193,7 +193,7 @@ class ERC20::Test < Minitest::Test
             true
           end
           yield(
-            ERC20::Wallet.new(host: '127.0.0.1', port:, ws_path: '/', ssl: false, log: fake_loog),
+            ERC20::Wallet.new(host: '127.0.0.1', port:, ws_path: '/', ssl: false, log:),
             received
           )
         ensure


### PR DESCRIPTION
An error response carries the request `id` just like a successful one, so
the message handler in `accept` used to mark every address as active when
the node had in fact rejected the subscribe. The periodic timer then found
nothing to do, no `eth_subscription` event could ever arrive, and the
process waited forever while incoming payments went by unnoticed. Now the
error goes to the log at error level, the addresses stay out of `active`,
and the timer sends the subscribe again after `delay` seconds. Frames that
fail to parse are logged too, instead of turning into an empty hash without
a trace.

Three tests on the fake node cover it: a rejected subscribe leaves `active`
empty, it is retried rather than being the last attempt, and a corrupt frame
shows up in the log. The fake node now passes a String reply through
verbatim, which is the only way for a test to emit something that is not
valid JSON.

Problem 2 in the issue — the response id never being matched, and the
address list being read after the fact rather than as it was sent — is
already gone: #151 introduced `data['id'] == subscription_id` and the
`wanted` snapshot. Nothing to do there.

Closes #152