### PR TITLE
Fetch the logs missed while the socket was down

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,15 @@ w.accept(addresses) do |event|
   puts event[:amount] # how much, in tokens (1000000 = $1 USDT)
   puts event[:from] # who sent the payment
   puts event[:to] # who was the receiver
+  puts event[:block] # number of the block it was mined in
+  puts event[:index] # position of the log in the block
 end
 ```
+
+When the connection to the provider breaks, `accept` reconnects and fetches the
+logs of the blocks that were mined while it was away. A payment may reach the
+block twice because of that, so use `txn` and `index` together as the key of
+the payment and credit it only once.
 
 You can also check ETH balance and send ETH transactions:
 

--- a/lib/erc20/fake_wallet.rb
+++ b/lib/erc20/fake_wallet.rb
@@ -141,7 +141,9 @@ class ERC20::FakeWallet
         else
           {
             amount: 424_242,
+            block: 42,
             from: '0xd5ff1bfcde7a03da61ad229d962c74f1ea2f16a5',
+            index: 0,
             to: a,
             txn: TXN_HASH
           }

--- a/lib/erc20/wallet.rb
+++ b/lib/erc20/wallet.rb
@@ -408,6 +408,17 @@ class ERC20::Wallet
   # out of +active+, the error goes to the log, and the next subscribe attempt
   # happens +delay+ seconds later.
   #
+  # A dropped connection leaves a gap: the blocks mined between the disconnect
+  # and the confirmation of the new subscription are not streamed by the node.
+  # After a reconnect, the logs of that gap are fetched with +eth_getLogs+ and
+  # yielded before the live ones. A payment may arrive twice this way, because
+  # the gap starts at the block of the last payment seen, and the block must be
+  # ready for it: use +txn+ and +index+ of the event as the key of the payment.
+  #
+  # An exception from the block does not stop the stream: it goes to the log
+  # and the event is gone, since the node has no way of sending it again. The
+  # block must handle its own errors, if the payment must not be lost.
+  #
   # A reorganization of the chain may revert a payment that was already mined.
   # The node then re-sends its log with the +removed+ flag set. Such an event
   # is not yielded, since the payment never happened. In +raw+ mode the event
@@ -446,16 +457,17 @@ class ERC20::Wallet
   # @param [Boolean] raw TRUE if you need to get JSON events as they arrive from Websockets
   # @param [Integer] delay How many seconds to wait between +eth_subscribe+ calls
   # @param [Integer] subscription_id Unique ID of the subscription
+  # @param [Integer] since The number of the last block we have seen a payment in
   # @return [Websocket]
-  def reaccept(addresses, active, raw:, delay:, subscription_id:, &)
+  def reaccept(addresses, active, raw:, delay:, subscription_id:, since: nil, &)
     u = url(http: false)
     log_it(:debug, "Connecting ##{subscription_id} to #{u.hostname}:#{u.port}...")
-    contract = @contract
     log_url = "ws#{'s' if @ssl}://#{u.hostname}:#{u.port}"
     ws = Faye::WebSocket::Client.new(u.to_s, [], proxy: @proxy ? { origin: @proxy } : {}, ping: 60)
     timer = nil
     subscription = nil
     wanted = nil
+    height = since
     ws.on(:open) do
       safe do
         verbose do
@@ -482,17 +494,7 @@ class ERC20::Wallet
                   jsonrpc: '2.0',
                   id: subscription_id,
                   method: 'eth_subscribe',
-                  params: [
-                    'logs',
-                    {
-                      address: contract,
-                      topics: [
-                        '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
-                        nil,
-                        wanted.map { |a| "0x000000000000000000000000#{a[2..]}" }
-                      ]
-                    }
-                  ]
+                  params: ['logs', to_filter(wanted)]
                 }.to_json
               )
               # rubocop:enable Style/Send
@@ -521,30 +523,29 @@ class ERC20::Wallet
               "Subscribed ##{subscription_id} to #{active.to_a.size} addresses at #{log_url}: " \
               "#{active.to_a.map { |a| a[0..6] }.join(', ')}"
             )
-          elsif data['method'] == 'eth_subscription' && data.dig('params', 'result')
-            event = data['params']['result']
-            if raw
-              log_it(:debug, "New event arrived from #{event['address']}")
-              yield(event)
-            elsif event['removed']
-              log_it(
-                :debug,
-                "Payment in #{event['transactionHash']} is reverted by a reorganization of the chain, ignoring it"
+            if since
+              # rubocop:disable Style/Send
+              ws.send(
+                {
+                  jsonrpc: '2.0',
+                  id: subscription_id + 2,
+                  method: 'eth_getLogs',
+                  params: [to_filter(wanted).merge(fromBlock: format('0x%x', since + 1), toBlock: 'latest')]
+                }.to_json
               )
-            else
-              event = {
-                amount: event['data'].to_i(16),
-                from: "0x#{event['topics'][1][26..].downcase}",
-                to: "0x#{event['topics'][2][26..].downcase}",
-                txn: event['transactionHash'].downcase
-              }
-              log_it(
-                :debug,
-                "Payment of #{event[:amount]} tokens arrived at ##{subscription_id} " \
-                "from #{event[:from]} to #{event[:to]} in #{event[:txn]}"
-              )
-              yield(event)
+              # rubocop:enable Style/Send
+              log_it(:debug, "Requested ##{subscription_id} the logs of the blocks after ##{since}")
+              since = nil
             end
+          elsif data['id'] == subscription_id + 2
+            log_it(:debug, "Received #{data['result'].size} logs mined while ##{subscription_id} was offline")
+            data['result'].each do |log|
+              height = [height, log['blockNumber'].to_s.to_i(16)].compact.max
+              deliver(log, raw:, id: subscription_id, &)
+            end
+          elsif data['method'] == 'eth_subscription' && data.dig('params', 'result')
+            height = [height, data['params']['result']['blockNumber'].to_s.to_i(16)].compact.max
+            deliver(data['params']['result'], raw:, id: subscription_id, &)
           end
         end
       end
@@ -555,7 +556,9 @@ class ERC20::Wallet
           log_it(:debug, "Disconnected ##{subscription_id} from #{log_url}")
           active.clear
           timer&.cancel
-          reaccept(addresses, active, raw:, delay:, subscription_id: subscription_id + 1, &)
+          EventMachine.add_timer(delay) do
+            reaccept(addresses, active, raw:, delay:, subscription_id: subscription_id + 1, since: height, &)
+          end
         end
       end
     end
@@ -566,6 +569,51 @@ class ERC20::Wallet
         end
       end
     end
+  end
+
+  def to_filter(addresses)
+    {
+      address: @contract,
+      topics: [
+        TRANSFER,
+        nil,
+        addresses.to_a.map { |a| "0x000000000000000000000000#{a[2..]}" }
+      ]
+    }
+  end
+
+  def to_event(log)
+    {
+      amount: log['data'].to_i(16),
+      block: log['blockNumber'].to_s.to_i(16),
+      from: "0x#{log['topics'][1][26..].downcase}",
+      index: log['logIndex'].to_s.to_i(16),
+      to: "0x#{log['topics'][2][26..].downcase}",
+      txn: log['transactionHash'].downcase
+    }
+  end
+
+  def deliver(log, raw:, id:, &)
+    if raw
+      log_it(:debug, "New event arrived from #{log['address']}")
+      digest(log, log['transactionHash'], &)
+    elsif log['removed']
+      log_it(:debug, "Payment in #{log['transactionHash']} is reverted by a reorganization of the chain, ignoring it")
+    else
+      event = to_event(log)
+      log_it(
+        :debug,
+        "Payment of #{event[:amount]} tokens arrived at ##{id} " \
+        "from #{event[:from]} to #{event[:to]} in #{event[:txn]}"
+      )
+      digest(event, event[:txn], &)
+    end
+  end
+
+  def digest(event, txn)
+    yield(event)
+  rescue StandardError => e
+    log_it(:error, "The block failed to process the payment in #{txn}, the event is lost (#{e.class}): #{e.message}")
   end
 
   def to_json(msg)

--- a/test/erc20/test_wallet.rb
+++ b/test/erc20/test_wallet.rb
@@ -223,23 +223,29 @@ class TestWallet < ERC20::Test
     assert_equal(1, sent.uniq.size)
   end
 
+  def to_log(amount, removed: false, block: '0x10', index: '0x3')
+    {
+      address: ERC20::Wallet::USDT,
+      blockNumber: block,
+      data: format('0x%064x', amount),
+      logIndex: index,
+      removed:,
+      topics: [
+        ERC20::Wallet::TRANSFER,
+        "0x000000000000000000000000#{Eth::Key.new(priv: JEFF).address.to_s.downcase[2..]}",
+        "0x000000000000000000000000#{Eth::Key.new(priv: WALTER).address.to_s.downcase[2..]}"
+      ],
+      transactionHash: "0x#{'e' * 64}"
+    }
+  end
+
   def transfer(amount, removed)
     {
       jsonrpc: '2.0',
       method: 'eth_subscription',
       params: {
         subscription: '0x42',
-        result: {
-          address: ERC20::Wallet::USDT,
-          data: format('0x%064x', amount),
-          removed:,
-          topics: [
-            ERC20::Wallet::TRANSFER,
-            "0x000000000000000000000000#{Eth::Key.new(priv: JEFF).address.to_s.downcase[2..]}",
-            "0x000000000000000000000000#{Eth::Key.new(priv: WALTER).address.to_s.downcase[2..]}"
-          ],
-          transactionHash: "0x#{'e' * 64}"
-        }
+        result: to_log(amount, removed:)
       }
     }
   end
@@ -311,6 +317,101 @@ class TestWallet < ERC20::Test
       subscribes = File.readlines(received).count { |line| JSON.parse(line)['method'] == 'eth_subscribe' }
     end
     assert_equal(2, subscribes)
+  end
+
+  def test_yields_a_complete_payment
+    WebMock.enable_net_connect!
+    event = nil
+    on_websockets([[{ jsonrpc: '2.0', id: 42, result: '0x42' }, transfer(555, false)]]) do |wallet|
+      daemon =
+        Thread.new do
+          wallet.accept([Eth::Key.new(priv: WALTER).address.to_s.downcase], [], subscription_id: 42) do |e|
+            event = e
+          end
+        end
+      wait_for(10) { event }
+      daemon.kill
+      daemon.join(30)
+    end
+    assert_equal(
+      {
+        amount: 555,
+        block: 16,
+        from: Eth::Key.new(priv: JEFF).address.to_s.downcase,
+        index: 3,
+        to: Eth::Key.new(priv: WALTER).address.to_s.downcase,
+        txn: "0x#{'e' * 64}"
+      },
+      event
+    )
+  end
+
+  def test_complains_when_the_block_fails
+    WebMock.enable_net_connect!
+    buf = Loog::Buffer.new
+    on_websockets([[{ jsonrpc: '2.0', id: 42, result: '0x42' }, transfer(777, false)]], log: buf) do |wallet|
+      daemon =
+        Thread.new do
+          wallet.accept([Eth::Key.new(priv: WALTER).address.to_s.downcase], [], subscription_id: 42) do |_|
+            raise(StandardError, 'The database is down')
+          end
+        end
+      wait_for(10) { buf.to_s.include?('is lost') }
+      daemon.kill
+      daemon.join(30)
+    end
+    assert_match(/#{'e' * 64}, the event is lost/, buf.to_s, 'A lost payment cannot stay unnamed in the log')
+  end
+
+  def reconnection
+    [
+      [{ jsonrpc: '2.0', id: 'echo', result: '0xaaa' }, transfer(555, false)],
+      [{ jsonrpc: '2.0', id: 'echo', result: [to_log(888, block: '0x20', index: '0x1')] }]
+    ]
+  end
+
+  def test_asks_for_the_logs_of_the_gap
+    WebMock.enable_net_connect!
+    sent = []
+    on_websockets(reconnection) do |wallet, received, reboot|
+      events = []
+      daemon =
+        Thread.new do
+          wallet.accept([Eth::Key.new(priv: WALTER).address.to_s.downcase], [], subscription_id: 42) do |e|
+            events.append(e)
+          end
+        end
+      wait_for(10) { !events.empty? }
+      reboot.call
+      wait_for(20) do
+        sent = File.readlines(received).map { |line| JSON.parse(line) }
+        sent.any? { |m| m['method'] == 'eth_getLogs' }
+      end
+      daemon.kill
+      daemon.join(30)
+    end
+    assert_equal('0x11', sent.find { |m| m['method'] == 'eth_getLogs' }['params'].first['fromBlock'])
+  end
+
+  def test_yields_the_payment_missed_while_offline
+    WebMock.enable_net_connect!
+    missed = nil
+    on_websockets(reconnection) do |wallet, _received, reboot|
+      events = []
+      daemon =
+        Thread.new do
+          wallet.accept([Eth::Key.new(priv: WALTER).address.to_s.downcase], [], subscription_id: 42) do |e|
+            events.append(e)
+          end
+        end
+      wait_for(10) { !events.empty? }
+      reboot.call
+      wait_for(20) { events.any? { |e| e[:amount] == 888 } }
+      missed = events.find { |e| e[:amount] == 888 }
+      daemon.kill
+      daemon.join(30)
+    end
+    assert_equal(32, missed[:block], 'A payment mined during the outage cannot stay undelivered')
   end
 
   def rejection

--- a/test/fake_node.rb
+++ b/test/fake_node.rb
@@ -17,7 +17,8 @@ require_relative '../lib/erc20/erc20'
 # appended to the given file, one per line.
 #
 # A reply that is a String travels to the client verbatim, which is how a
-# test emits a frame that is not valid JSON.
+# test emits a frame that is not valid JSON. A reply with the +id+ of "echo"
+# gets the +id+ of the message it answers, the way a real node does it.
 class ERC20::FakeNode
   def initialize(port, replies, received)
     @port = port
@@ -33,13 +34,21 @@ class ERC20::FakeNode
           File.open(@received, 'a') { |f| f.puts(msg) }
           (@replies[seen] || []).each do |reply|
             # rubocop:disable Style/Send
-            ws.send(reply.is_a?(String) ? reply : JSON.dump(reply))
+            ws.send(to_frame(reply, msg))
             # rubocop:enable Style/Send
           end
           seen += 1
         end
       end
     end
+  end
+
+  private
+
+  def to_frame(reply, msg)
+    return reply if reply.is_a?(String)
+    reply = reply.merge('id' => JSON.parse(msg)['id']) if reply['id'] == 'echo'
+    JSON.dump(reply)
   end
 end
 

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -178,7 +178,9 @@ class ERC20::Test < Minitest::Test
   # a wallet connected to it. The +replies+ is a list of groups of JSON
   # messages: the node answers the first message of the wallet with the first
   # group, the second one with the second group, and so on. The block gets the
-  # wallet and the name of the file where all messages from the wallet land.
+  # wallet, the name of the file where all messages from the wallet land, and
+  # a lambda that kills the node and starts a new one on the same port, in
+  # order to break the connection the way a real provider does.
   def on_websockets(replies, log: fake_loog)
     Dir.mktmpdir do |home|
       script = File.join(home, 'replies.json')
@@ -186,19 +188,29 @@ class ERC20::Test < Minitest::Test
       received = File.join(home, 'received.txt')
       FileUtils.touch(received)
       RandomPort::Pool::SINGLETON.acquire do |port|
-        pid = spawn(RbConfig.ruby, File.join(__dir__, 'fake_node.rb'), port.to_s, script, received, out: File::NULL)
-        begin
-          wait_for do
-            TCPSocket.new('127.0.0.1', port).close
-            true
+        pids = []
+        node = [RbConfig.ruby, File.join(__dir__, 'fake_node.rb'), port.to_s, script, received]
+        reboot =
+          lambda do
+            pids.each { |pid| Process.kill('KILL', pid) }
+            pids.append(spawn(*node, out: File::NULL))
+            wait_for do
+              TCPSocket.new('127.0.0.1', port).close
+              true
+            end
           end
+        reboot.call
+        begin
           yield(
             ERC20::Wallet.new(host: '127.0.0.1', port:, ws_path: '/', ssl: false, log:),
-            received
+            received,
+            reboot
           )
         ensure
-          Process.kill('KILL', pid)
-          Process.wait(pid)
+          pids.each do |pid|
+            Process.kill('KILL', pid)
+            Process.wait(pid)
+          end
         end
       end
     end


### PR DESCRIPTION
A subscription streams only what comes after it, so every payment mined
between a disconnect and the confirmation of the new subscription used to
vanish. The number of the last block a payment was seen in now survives the
reconnect, and once the new subscription is confirmed, the logs of the gap
are fetched with `eth_getLogs` over the same socket and yielded before the
live ones. Because the gap starts at that block, a payment may be delivered
twice, so the event carries `block` and `index` too: together with `txn`
they make a key the caller can credit on exactly once.

Reconnecting used to happen with no pause at all. Against a closed port
that loop got hot enough to exhaust EventMachine's timer pool, and `accept`
died with "ran out of timers" — the listener gone for the rest of the
process. It waits `delay` seconds between attempts now. The new gap test
found this, not a review.

An exception from the caller's block still doesn't stop the stream, but it
no longer disappears quietly: the log line names the transaction that was
dropped, so it can be found and credited by hand. Note that the backtrace
is not logged there, because `backtrace` is a development dependency only
and `Backtrace` is not defined at runtime for anyone who installs the gem.

Closes #153