### PR TITLE
Convert CLI amounts exactly, without Float

### DIFF
--- a/bin/erc20
+++ b/bin/erc20
@@ -151,10 +151,10 @@ class Bin < Thor
       amount = amount.to_i
       log.debug("The token amount equals to #{amount} ERC20 tokens (as provided)")
     elsif /^[0-9]+(\.[0-9]+)?usdt$/.match?(amount)
-      amount = (amount.gsub(/usdt$/, '').to_f * 1_000_000).to_i
+      amount = units(amount.gsub(/usdt$/, ''), 1_000_000)
       log.debug("The USDT amount equals to #{amount} ERC20 tokens")
     elsif /^\$[0-9]+(\.[0-9]+)?$/.match?(amount)
-      amount = (amount.gsub(/^\$/, '').to_f * 1_000_000).to_i
+      amount = units(amount.gsub(/^\$/, ''), 1_000_000)
       log.debug("The dollar amount equals to #{amount} ERC20 tokens")
     else
       raise "Can't understand amount: #{amount.inspect}"
@@ -165,15 +165,23 @@ class Bin < Thor
   def wei(amount)
     if /^[0-9]+$/.match?(amount)
       amount.to_i
-    elsif /[0-9]wei$/.match?(amount)
+    elsif /^[0-9]+wei$/.match?(amount)
       amount.gsub(/wei$/, '').to_i
-    elsif /[0-9]gwei$/.match?(amount)
-      (amount.gsub(/gwei$/, '').to_f * 1_000_000_000).to_i
-    elsif /[0-9]eth$/.match?(amount)
-      (amount.gsub(/eth$/, '').to_f * 1_000_000_000_000_000_000).to_i
+    elsif /^[0-9]+(\.[0-9]+)?gwei$/.match?(amount)
+      units(amount.gsub(/gwei$/, ''), 1_000_000_000)
+    elsif /^[0-9]+(\.[0-9]+)?eth$/.match?(amount)
+      units(amount.gsub(/eth$/, ''), 1_000_000_000_000_000_000)
     else
       raise "Can't understand amount: #{amount.inspect}"
     end
+  end
+
+  def units(amount, factor)
+    exact = Rational(amount) * factor
+    unless exact.denominator == 1
+      raise "Amount #{amount.inspect} is too precise, while the smallest unit is 1/#{factor}"
+    end
+    exact.numerator
   end
 end
 

--- a/features/dry.feature
+++ b/features/dry.feature
@@ -28,6 +28,10 @@ Feature: Command Line Processing, in Dry Mode
     When I run bin/erc20 with "pay --dry --verbose 46feba063e9b59a8ae0dba68abd39a3cb8f52089e776576d6eb1bb5bfec123d1 0x7232148927F8a580053792f44D4d59d40Fd00ABD 10usdt"
     Then Exit code is zero
 
+  Scenario: ERC20 payment in USDT keeps every token unit
+    When I run bin/erc20 with "pay --dry --verbose 46feba063e9b59a8ae0dba68abd39a3cb8f52089e776576d6eb1bb5bfec123d1 0x7232148927F8a580053792f44D4d59d40Fd00ABD 8.2usdt"
+    Then Stdout contains "Sending 8200000 ERC20 tokens"
+
   Scenario: ETH payment can be sent in wei
     When I run bin/erc20 with "eth_pay --dry --verbose 46feba063e9b59a8ae0dba68abd39a3cb8f52089e776576d6eb1bb5bfec123d1 0x7232148927F8a580053792f44D4d59d40Fd00ABD 10000000"
     Then Exit code is zero
@@ -35,3 +39,7 @@ Feature: Command Line Processing, in Dry Mode
   Scenario: ETH payment can be sent in ETH
     When I run bin/erc20 with "eth_pay --dry --verbose 46feba063e9b59a8ae0dba68abd39a3cb8f52089e776576d6eb1bb5bfec123d1 0x7232148927F8a580053792f44D4d59d40Fd00ABD 1eth"
     Then Exit code is zero
+
+  Scenario: ETH payment smaller than one wei is rejected
+    When I run bin/erc20 with "eth_pay --dry 46feba063e9b59a8ae0dba68abd39a3cb8f52089e776576d6eb1bb5bfec123d1 0x7232148927F8a580053792f44D4d59d40Fd00ABD 0.0000000000000000001eth"
+    Then Exit code is not zero

--- a/test/erc20/test_bin.rb
+++ b/test/erc20/test_bin.rb
@@ -56,6 +56,30 @@ class TestBin < ERC20::Test
     assert_match(/^0x[a-f0-9]{64}$/, qbash(bin, 'pay', pvt, address, '\$2.50', '--dry').strip, 'txn hash is not valid')
   end
 
+  def test_sends_exact_amount_of_usdt
+    assert_includes(
+      qbash(bin, 'pay', pvt, address, '8.2usdt', '--dry', '--verbose'),
+      'Sending 8200000 ERC20 tokens',
+      'An amount in USDT cannot lose a token unit on the way'
+    )
+  end
+
+  def test_sends_exact_amount_of_dollars
+    assert_includes(
+      qbash(bin, 'pay', pvt, address, '\$8.20', '--dry', '--verbose'),
+      'Sending 8200000 ERC20 tokens',
+      'An amount in dollars cannot lose a token unit on the way'
+    )
+  end
+
+  def test_rejects_a_too_precise_usdt_amount
+    assert_includes(
+      qbash(bin, 'pay', pvt, address, '0.0000001usdt', '--dry', accept: [255]),
+      'is too precise',
+      'An amount smaller than one token cannot be truncated silently'
+    )
+  end
+
   def test_sends_eth_payment
     assert_match(
       /^0x[a-f0-9]{64}$/, qbash(bin, 'eth_pay', pvt, address, '1000', '--dry').strip,
@@ -81,6 +105,38 @@ class TestBin < ERC20::Test
     assert_match(
       /^0x[a-f0-9]{64}$/, qbash(bin, 'eth_pay', pvt, address, '0.001eth', '--dry').strip,
       'txn hash is not valid'
+    )
+  end
+
+  def test_sends_exact_amount_of_gwei
+    assert_includes(
+      qbash(bin, 'eth_pay', pvt, address, '8.2gwei', '--dry', '--verbose'),
+      'Sending 8200000000 wei',
+      'An amount in gwei cannot lose a wei on the way'
+    )
+  end
+
+  def test_sends_exact_amount_of_eth
+    assert_includes(
+      qbash(bin, 'eth_pay', pvt, address, '8.2eth', '--dry', '--verbose'),
+      'Sending 8200000000000000000 wei',
+      'An amount in ETH cannot lose a thousand wei on the way'
+    )
+  end
+
+  def test_rejects_a_too_precise_eth_amount
+    assert_includes(
+      qbash(bin, 'eth_pay', pvt, address, '0.0000000000000000001eth', '--dry', accept: [255]),
+      'is too precise',
+      'An amount smaller than one wei cannot be truncated silently'
+    )
+  end
+
+  def test_rejects_fractional_amount_of_wei
+    assert_includes(
+      qbash(bin, 'eth_pay', pvt, address, '1.5wei', '--dry', accept: [255]),
+      'Can\'t understand amount',
+      'A fraction of a wei cannot be rounded down silently'
     )
   end
 


### PR DESCRIPTION
The CLI turned human-readable amounts into integers through `Float`, and
`to_i` chopped off whatever the binary representation got wrong. That is why
`pay KEY ADDR 8.2usdt` sent 8199999 tokens and `eth_pay ... 8.2eth` was 1024
wei short. Both now go through `Rational`, which holds the decimal exactly, so
the numbers from the issue come out right: 8200000 tokens, 8200000000 wei for
`8.2gwei`, and 8200000000000000000 wei for `8.2eth`.

An amount finer than the unit used to collapse to zero and then fail later on
the positivity check with a confusing message. Now the conversion refuses it
right away: `0.0000001usdt` and `0.0000000000000000001eth` both exit with
"is too precise, while the smallest unit is 1/1000000". I also anchored the
`wei`/`gwei`/`eth` regexes, which were open at the start and only worked
because `eth_pay` pre-validates with its own anchored one. That closes the
same silent-truncation hole for a fraction of a wei: `1.5wei` used to become
1 wei, now it is refused.

I went with `Rational` rather than `BigDecimal` because `bigdecimal` is a
bundled gem and would need a new runtime dependency in the gemspec, while
`Rational()` is core and parses decimal strings exactly. Seven new tests in
`test_bin.rb` and two scenarios in `dry.feature` cover the conversions and the
refusals; all of them were red before the fix.

Closes #154