### PR TITLE
Send type-2 transactions instead of legacy ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ To check the price of a gas unit and the expected cost of a payment:
 # How many gas units required to send this payment:
 units = w.gas_estimate(from, to, amount)
 
-# What is the price of a gas unit, in wei:
+# What is the most a gas unit may cost, in wei (payments are type-2,
+# thus the network charges only the base fee plus the tip):
 price = w.gas_price
 ```
 

--- a/lib/erc20/wallet.rb
+++ b/lib/erc20/wallet.rb
@@ -262,6 +262,10 @@ class ERC20::Wallet
   # price mineable, we double the base fee (a buffer that absorbs several blocks
   # of base-fee growth) and add a priority tip (+GAS_PRICE_TIP+).
   #
+  # The price is a ceiling, not a payment: it lands in the +maxFeePerGas+ of a
+  # type-2 transaction, where the network charges only +baseFee + tip+ per gas
+  # unit and refunds the rest of the buffer.
+  #
   # @return [Integer] Price of gas unit, in wei (1 gwei = 0.000000001 ETH)
   def gas_price
     block =
@@ -269,7 +273,9 @@ class ERC20::Wallet
         jr.eth_getBlockByNumber('latest', false)
       end
     raise(StandardError, "Can't get gas price, try again later") if block.nil?
-    base = block['baseFeePerGas'].to_i(16)
+    fee = block['baseFeePerGas']
+    raise(StandardError, 'The latest block has no baseFeePerGas, the chain is not EIP-1559 capable') if fee.nil?
+    base = fee.to_i(16)
     price = (base * 2) + GAS_PRICE_TIP
     log_it(:debug, "The base fee is #{base} wei, the cost of one gas unit is #{price} wei")
     price
@@ -290,11 +296,15 @@ class ERC20::Wallet
   # same signed transaction, which the network either mines once or rejects as
   # already known. Thus, no number of +attempts+ may pay twice.
   #
+  # The transaction is a type-2 one (EIP-1559): the +price+ is the most the
+  # sender agrees to pay per gas unit, while the actual payment is only
+  # +baseFee + GAS_PRICE_TIP+.
+  #
   # @param [String] priv Private key, in hex
   # @param [String] address Public key, in hex
   # @param [Integer] amount The amount of ERC20 tokens to send
   # @param [Integer] limit How much gas you're ready to spend
-  # @param [Integer] price How much gas you pay per computation unit
+  # @param [Integer] price The most you pay per computation unit
   # @return [String] Transaction hash
   def pay(priv, address, amount, limit: nil, price: gas_price)
     raise(ArgumentError, 'Private key can\'t be nil') unless priv
@@ -312,10 +322,9 @@ class ERC20::Wallet
       raise(ArgumentError, "Gas limit #{limit} is below #{Eth::Tx::DEFAULT_GAS_LIMIT}") if limit < Eth::Tx::DEFAULT_GAS_LIMIT
       raise(ArgumentError, "Gas limit #{limit} is above #{Eth::Tx::BLOCK_GAS_LIMIT}") if limit > Eth::Tx::BLOCK_GAS_LIMIT
     end
-    if price
-      raise(ArgumentError, 'Gas price must be an Integer') unless price.is_a?(Integer)
-      raise(ArgumentError, 'Gas price must be a positive Integer') unless price.positive?
-    end
+    raise(ArgumentError, 'Gas price can\'t be nil') unless price
+    raise(ArgumentError, 'Gas price must be an Integer') unless price.is_a?(Integer)
+    raise(ArgumentError, 'Gas price must be a positive Integer') unless price.positive?
     key = Eth::Key.new(priv: priv)
     from = key.address.to_s
     tnx =
@@ -323,7 +332,8 @@ class ERC20::Wallet
         tx = Eth::Tx.new(
           {
             nonce: with_jsonrpc { |jr| jr.eth_getTransactionCount(from, 'pending').to_i(16) },
-            gas_price: price,
+            max_gas_fee: price,
+            priority_fee: tip(price),
             gas_limit: limit || gas_estimate(from, address, amount),
             to: @contract,
             value: 0,
@@ -345,7 +355,7 @@ class ERC20::Wallet
   # @param [String] priv Private key, in hex
   # @param [String] address Public key, in hex
   # @param [Integer] amount The amount of ETH to send
-  # @param [Integer] price How much gas you pay per computation unit
+  # @param [Integer] price The most you pay per computation unit
   # @return [String] Transaction hash
   def eth_pay(priv, address, amount, price: gas_price)
     raise(ArgumentError, 'Private key can\'t be nil') unless priv
@@ -357,10 +367,9 @@ class ERC20::Wallet
     raise(ArgumentError, 'Amount can\'t be nil') unless amount
     raise(ArgumentError, "Amount (#{amount}) must be an Integer") unless amount.is_a?(Integer)
     raise(ArgumentError, "Amount (#{amount}) must be a positive Integer") unless amount.positive?
-    if price
-      raise(ArgumentError, 'Gas price must be an Integer') unless price.is_a?(Integer)
-      raise(ArgumentError, 'Gas price must be a positive Integer') unless price.positive?
-    end
+    raise(ArgumentError, 'Gas price can\'t be nil') unless price
+    raise(ArgumentError, 'Gas price must be an Integer') unless price.is_a?(Integer)
+    raise(ArgumentError, 'Gas price must be a positive Integer') unless price.positive?
     key = Eth::Key.new(priv: priv)
     from = key.address.to_s
     tnx =
@@ -369,7 +378,8 @@ class ERC20::Wallet
           {
             chain_id: @chain,
             nonce: with_jsonrpc { |jr| jr.eth_getTransactionCount(from, 'pending').to_i(16) },
-            gas_price: price,
+            max_gas_fee: price,
+            priority_fee: tip(price),
             gas_limit: 22_000,
             to: address,
             value: amount
@@ -667,6 +677,10 @@ class ERC20::Wallet
       sleep(pause)
       retry
     end
+  end
+
+  def tip(price)
+    [GAS_PRICE_TIP, price].min
   end
 
   def to_pay_data(address, amount)

--- a/test/erc20/test_wallet.rb
+++ b/test/erc20/test_wallet.rb
@@ -559,6 +559,99 @@ class TestWallet < ERC20::Test
     assert_equal("0xa9059cbb000000000000000000000000#{walter.downcase[2..]}#{'f' * 64}", data)
   end
 
+  def signed
+    WebMock.disable_net_connect!
+    sent = []
+    stub_request(:post, 'https://example.org/').to_return do |request|
+      call = JSON.parse(request.body)
+      sent.append(call['params'].first) if call['method'] == 'eth_sendRawTransaction'
+      {
+        status: 200,
+        body: {
+          jsonrpc: '2.0', id: call['id'],
+          result:
+            case call['method']
+            when 'eth_getBlockByNumber' then { 'baseFeePerGas' => '0x4a817c800' }
+            when 'eth_sendRawTransaction' then "0x#{'f' * 64}"
+            else '0xfde8'
+            end
+        }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      }
+    end
+    yield(ERC20::Wallet.new(host: 'example.org', http_path: '/', log: Loog::NULL))
+    Eth::Tx.decode(sent.last)
+  end
+
+  def test_pays_with_a_dynamic_fee_transaction
+    assert_kind_of(
+      Eth::Tx::Eip1559,
+      signed { |w| w.pay(JEFF, Eth::Key.new(priv: WALTER).address.to_s, 1000) },
+      'A legacy transaction gives away the entire gas price, thus it cannot be used'
+    )
+  end
+
+  def test_pays_eth_with_a_dynamic_fee_txn
+    assert_kind_of(
+      Eth::Tx::Eip1559,
+      signed { |w| w.eth_pay(JEFF, Eth::Key.new(priv: WALTER).address.to_s, 1000) },
+      'A legacy transaction gives away the entire gas price, thus it cannot be used'
+    )
+  end
+
+  def test_caps_the_fee_at_the_gas_price
+    assert_equal(
+      41_000_000_000,
+      signed { |w| w.pay(JEFF, Eth::Key.new(priv: WALTER).address.to_s, 1000) }.max_fee_per_gas,
+      'The doubled base fee cannot be anything but a ceiling'
+    )
+  end
+
+  def test_tips_the_proposer_a_gwei
+    assert_equal(
+      ERC20::Wallet::GAS_PRICE_TIP,
+      signed { |w| w.pay(JEFF, Eth::Key.new(priv: WALTER).address.to_s, 1000) }.max_priority_fee_per_gas,
+      'The tip cannot swallow the headroom left for the growth of the base fee'
+    )
+  end
+
+  def test_never_tips_above_the_fee_cap
+    assert_equal(
+      1000,
+      signed do |w|
+        w.pay(JEFF, Eth::Key.new(priv: WALTER).address.to_s, 1000, price: 1000)
+      end.max_priority_fee_per_gas,
+      'A tip above the fee cap cannot be accepted by any node'
+    )
+  end
+
+  def test_rejects_a_nil_gas_price
+    WebMock.disable_net_connect!
+    w = ERC20::Wallet.new(host: 'example.org', http_path: '/', log: Loog::NULL)
+    assert_match(
+      /Gas price can't be nil/,
+      assert_raises(ArgumentError) do
+        w.eth_pay(JEFF, Eth::Key.new(priv: WALTER).address.to_s, 1000, price: nil)
+      end.message,
+      'A payment without a gas price cannot reach the signing of the transaction'
+    )
+  end
+
+  def test_rejects_a_chain_without_a_base_fee
+    WebMock.disable_net_connect!
+    stub_request(:post, 'https://example.org/').to_return(
+      body: { jsonrpc: '2.0', id: 42, result: { 'number' => '0x1' } }.to_json,
+      headers: { 'Content-Type' => 'application/json' }
+    )
+    assert_match(
+      /baseFeePerGas/,
+      assert_raises(StandardError) do
+        ERC20::Wallet.new(host: 'example.org', http_path: '/', log: Loog::NULL).gas_price
+      end.message,
+      'A chain without EIP-1559 cannot fail deep inside with an obscure message'
+    )
+  end
+
   def test_rejects_gas_limit_below_minimum
     WebMock.disable_net_connect!
     w = ERC20::Wallet.new(host: 'example.org', http_path: '/', log: Loog::NULL)


### PR DESCRIPTION
`pay` and `eth_pay` now hand `max_gas_fee` and `priority_fee` to `Eth::Tx.new` instead of `gas_price`, which makes the signed transaction a type-2 (EIP-1559) one. The `price` argument keeps its place and becomes the fee cap, so nothing changes for callers. `gas_price` itself is untouched arithmetically — it still returns `2×base + 1 gwei` — only its meaning shifts from "what you pay" to "the most you agree to pay".

That matters because a legacy transaction hands the entire `gasPrice` to the proposer. The doubling that keeps a payment mineable while the base fee climbs was therefore not a buffer at all, it was a tip of about half of every gas bill. In the same slot of a type-2 transaction the doubling is a ceiling and the network charges only `baseFee + tip`. I checked it on Hardhat: the receipt comes back with `type: 0x2`, `maxFeePerGas` equal to the price, and `effectiveGasPrice` down at `baseFee + 1 gwei`.

Two smaller things came along. The tip is capped at the fee cap (`[GAS_PRICE_TIP, price].min`), because a tip above the cap is rejected by every node and the existing tests already pass `price: 1000`. And `gas_price` now complains about a missing `baseFeePerGas` in one sentence, where it used to die with `wrong number of arguments (given 1, expected 0)` from `nil.to_i(16)` — that was the second half of the issue. As a consequence `price: nil` is now refused up front rather than deep inside the `eth` gem.

Closes #155