### PR TITLE
Close the fail-fast gaps of accept

### DIFF
--- a/lib/erc20/wallet.rb
+++ b/lib/erc20/wallet.rb
@@ -407,7 +407,10 @@ class ERC20::Wallet
   #
   # The +addresses+ must have +to_a()+ implemented. This method will be
   # called every +delay+ seconds. It is expected that it returns the list
-  # of Ethereum public addresses that must be monitored.
+  # of Ethereum public addresses that must be monitored. Every address must
+  # be a hex with the +0x+ prefix, both at the start and later, when the list
+  # changes: a malformed address makes the filter of the subscription target
+  # a different address, thus payments are never seen.
   #
   # The +active+ must have +append()+, +clear()+ and +to_a()+ implemented. This
   # array holds the addresses that the node has confirmed a subscription for,
@@ -442,17 +445,18 @@ class ERC20::Wallet
   # @param [Array<String>] addresses Addresses to monitor
   # @param [Array] active List of addresses that we are actually listening to
   # @param [Boolean] raw TRUE if you need to get JSON events as they arrive from Websockets
-  # @param [Integer] delay How many seconds to wait between +eth_subscribe+ calls
+  # @param [Numeric] delay How many seconds to wait between +eth_subscribe+ calls
   # @param [Integer] subscription_id Unique ID of the subscription
-  def accept(addresses, active = [], raw: false, delay: 1, subscription_id: rand(99_999), &)
+  def accept(addresses, active = [], raw: false, delay: 1, subscription_id: rand(1..99_999), &)
     raise(ArgumentError, 'Addresses can\'t be nil') unless addresses
     raise(ArgumentError, 'Addresses must respond to .to_a()') unless addresses.respond_to?(:to_a)
+    to_addresses(addresses)
     raise(ArgumentError, 'Active can\'t be nil') unless active
     raise(ArgumentError, 'Active must respond to .to_a()') unless active.respond_to?(:to_a)
     raise(ArgumentError, 'Active must respond to .append()') unless active.respond_to?(:append)
     raise(ArgumentError, 'Active must respond to .clear()') unless active.respond_to?(:clear)
-    raise(ArgumentError, 'Delay must be an Integer') unless delay.is_a?(Integer)
-    raise(ArgumentError, 'Delay must be a positive Integer or positive Float') unless delay.positive?
+    raise(ArgumentError, 'Delay must be a number') unless delay.is_a?(Numeric)
+    raise(ArgumentError, 'Delay must be a positive number') unless delay.positive?
     raise(ArgumentError, 'Subscription ID must be an Integer') unless subscription_id.is_a?(Integer)
     raise(ArgumentError, 'Subscription ID must be a positive Integer') unless subscription_id.positive?
     EventMachine.run do
@@ -465,7 +469,7 @@ class ERC20::Wallet
   # @param [Array<String>] addresses Addresses to monitor
   # @param [Array] active List of addresses that we are actually listening to
   # @param [Boolean] raw TRUE if you need to get JSON events as they arrive from Websockets
-  # @param [Integer] delay How many seconds to wait between +eth_subscribe+ calls
+  # @param [Numeric] delay How many seconds to wait between +eth_subscribe+ calls
   # @param [Integer] subscription_id Unique ID of the subscription
   # @param [Integer] since The number of the last block we have seen a payment in
   # @return [Websocket]
@@ -485,6 +489,7 @@ class ERC20::Wallet
           timer =
             EventMachine.add_periodic_timer(delay) do
               next if active.to_a.sort == addresses.to_a.sort
+              wanted = to_addresses(addresses).dup
               # rubocop:disable Style/Send
               if subscription
                 ws.send(
@@ -498,7 +503,6 @@ class ERC20::Wallet
                 log_it(:debug, "Requested to unsubscribe ##{subscription_id} from #{subscription}")
                 subscription = nil
               end
-              wanted = addresses.to_a.dup
               ws.send(
                 {
                   jsonrpc: '2.0',
@@ -578,6 +582,13 @@ class ERC20::Wallet
           log_it(:debug, "Failed ##{subscription_id} at #{log_url}: #{e.message}")
         end
       end
+    end
+  end
+
+  def to_addresses(addresses)
+    addresses.to_a.each do |a|
+      raise(ArgumentError, 'Each address must be a String') unless a.is_a?(String)
+      raise(ArgumentError, "Invalid format of the address (#{a})") unless /^0x[0-9a-fA-F]{40}$/.match?(a)
     end
   end
 

--- a/test/erc20/test_wallet.rb
+++ b/test/erc20/test_wallet.rb
@@ -13,6 +13,7 @@ require 'os'
 require 'random-port'
 require 'shellwords'
 require 'threads'
+require 'timeout'
 require 'typhoeus'
 require_relative '../../lib/erc20/wallet'
 require_relative '../test__helper'
@@ -464,6 +465,100 @@ class TestWallet < ERC20::Test
       daemon.join(30)
     end
     assert_match(/Failed to parse/, buf.to_s, 'A corrupt frame cannot be discarded silently')
+  end
+
+  def test_never_defaults_to_a_zero_subscription_id
+    WebMock.enable_net_connect!
+    seed = srand(177_660)
+    sent = []
+    on_websockets([[{ jsonrpc: '2.0', id: 1, result: '0x42' }]]) do |wallet, received|
+      daemon =
+        Thread.new do
+          wallet.accept([Eth::Key.new(priv: JEFF).address.to_s.downcase]) { |_| nil }
+        end
+      wait_for(10) { !File.readlines(received).empty? }
+      sent = File.readlines(received).map { |line| JSON.parse(line)['method'] }
+      daemon.kill
+      daemon.join(30)
+    end
+    assert_includes(
+      sent, 'eth_subscribe',
+      'The default subscription ID cannot be a zero, which the method rejects itself'
+    )
+  ensure
+    srand(seed)
+  end
+
+  def test_subscribes_with_a_fractional_delay
+    WebMock.enable_net_connect!
+    seen = []
+    on_websockets([[{ jsonrpc: '2.0', id: 42, result: '0x42' }]]) do |wallet|
+      active = []
+      daemon =
+        Thread.new do
+          wallet.accept(
+            [Eth::Key.new(priv: JEFF).address.to_s.downcase], active,
+            delay: 0.1, subscription_id: 42
+          ) { |_| nil }
+        end
+      wait_for(10) { !active.empty? }
+      seen = active.to_a.dup
+      daemon.kill
+      daemon.join(30)
+    end
+    refute_empty(seen, 'A fractional delay cannot be rejected, since the docs promise it works')
+  end
+
+  def test_rejects_an_address_without_a_prefix
+    WebMock.disable_net_connect!
+    wallet = ERC20::Wallet.new(host: 'example.org', log: Loog::NULL)
+    assert_match(
+      /Invalid format of the address/,
+      assert_raises(ArgumentError) do
+        Timeout.timeout(10) do
+          wallet.accept([Eth::Key.new(priv: JEFF).address.to_s.downcase[2..]]) { |_| nil }
+        end
+      end.message,
+      'An address without the 0x prefix cannot monitor a different address silently'
+    )
+  end
+
+  def test_rejects_a_nil_address_in_the_list
+    WebMock.disable_net_connect!
+    wallet = ERC20::Wallet.new(host: 'example.org', log: Loog::NULL)
+    assert_match(
+      /Each address must be a String/,
+      assert_raises(ArgumentError) do
+        Timeout.timeout(10) { wallet.accept([nil]) { |_| nil } }
+      end.message,
+      'A nil in the list of addresses cannot reach the filter of the subscription'
+    )
+  end
+
+  def test_rejects_an_address_added_at_runtime
+    WebMock.enable_net_connect!
+    addresses = [Eth::Key.new(priv: JEFF).address.to_s.downcase]
+    crashes = []
+    on_websockets(confirmations) do |wallet|
+      active = []
+      daemon =
+        Thread.new do
+          wallet.accept(addresses, active, subscription_id: 42) { |_| nil }
+        end
+      daemon.report_on_exception = false
+      wait_for(10) { !active.empty? }
+      addresses.append(Eth::Key.new(priv: WALTER).address.to_s.downcase[2..])
+      begin
+        daemon.join(10)
+      rescue ArgumentError => e
+        crashes.append(e.message)
+      end
+      daemon.kill
+    end
+    assert_match(
+      /Invalid format of the address/, crashes.first,
+      'An address that arrives later cannot skip the check'
+    )
   end
 
   def receipt(transfers, status: '0x1')


### PR DESCRIPTION
Three small guards in `accept`. The default subscription ID is now
`rand(1..99_999)`, so it can never come out as the zero that the
positivity check of the very same method rejects. Every monitored
address is checked against the same regex the rest of the class uses,
both when `accept` starts and every time the list changes while it runs.
And a `Float` delay is finally allowed.

The address check is the one that matters. An entry without the `0x`
prefix used to lose two real hex digits in the topic filter, so the node
happily confirmed a subscription to a completely different address and
the payments were never reported. One of the new tests shows exactly
that: before the fix the log says `Requested to subscribe to 2
addresses: 0xd5ff1, d7a63ac`. The delay was self-contradictory: the type
check said `Integer`, the message right below it promised
`positive Integer or positive Float`, `EventMachine` takes floats, and
`FakeWallet` is already tested with `delay: 0.1`.

Two things worth your eye. A malformed address that shows up at runtime
raises out of the reactor thread, which kills the whole `accept` loop —
loud, as the issue asks, but it does stop the monitoring, so a caller
that feeds the list from a database now has to keep it clean. And I
validate the list before the `eth_unsubscribe` goes out, otherwise a bad
entry would tear down a working subscription and only then complain.
`FakeWallet#accept` still validates nothing, which is #157.

Closes #156