### PR TITLE
Make FakeWallet reject what Wallet rejects

### DIFF
--- a/features/dry.feature
+++ b/features/dry.feature
@@ -21,7 +21,7 @@ Feature: Command Line Processing, in Dry Mode
     Then Exit code is zero
 
   Scenario: ERC20 payment can be sent in dollars
-    When I run bin/erc20 with "pay --dry --verbose 46feba063e9b59a8ae0dba68abd39a3cb8f52089e776576d6eb1bb5bfec123d1 0x7232148927F8a580053792f44D4d59d40Fd00ABD $10"
+    When I run bin/erc20 with "pay --dry --verbose 46feba063e9b59a8ae0dba68abd39a3cb8f52089e776576d6eb1bb5bfec123d1 0x7232148927F8a580053792f44D4d59d40Fd00ABD \$10"
     Then Exit code is zero
 
   Scenario: ERC20 payment can be sent in USDT

--- a/lib/erc20/checks.rb
+++ b/lib/erc20/checks.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'eth'
+require_relative 'erc20'
+
+# The checks that every wallet makes before it touches the network.
+#
+# A wallet deals with private keys, public addresses, and amounts of money. A
+# broken one of them either costs money or silently loses it, thus it is
+# rejected the moment it arrives. Both +ERC20::Wallet+ and +ERC20::FakeWallet+
+# make these very checks, so that a test that passes against the fake wallet
+# doesn't fail against a real provider.
+#
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2025 Yegor Bugayenko
+# License:: MIT
+module ERC20::Checks
+  HEX = /^0x[0-9a-fA-F]{40}$/
+  private_constant :HEX
+
+  MAX_AMOUNT = (2**256) - 1
+  private_constant :MAX_AMOUNT
+
+  private
+
+  def to_priv(priv)
+    raise(ArgumentError, 'Private key can\'t be nil') unless priv
+    raise(ArgumentError, 'Private key must be a String') unless priv.is_a?(String)
+    raise(ArgumentError, 'Invalid format of private key') unless /^[0-9a-fA-F]{64}$/.match?(priv)
+    priv
+  end
+
+  def to_address(address)
+    raise(ArgumentError, 'Address can\'t be nil') unless address
+    raise(ArgumentError, 'Address must be a String') unless address.is_a?(String)
+    raise(ArgumentError, 'Invalid format of the address') unless HEX.match?(address)
+    address
+  end
+
+  def to_addresses(addresses)
+    raise(ArgumentError, 'Addresses can\'t be nil') unless addresses
+    raise(ArgumentError, 'Addresses must respond to .to_a()') unless addresses.respond_to?(:to_a)
+    addresses.to_a.each do |a|
+      raise(ArgumentError, 'Each address must be a String') unless a.is_a?(String)
+      raise(ArgumentError, "Invalid format of the address (#{a})") unless HEX.match?(a)
+    end
+  end
+
+  def to_active(active)
+    raise(ArgumentError, 'Active can\'t be nil') unless active
+    raise(ArgumentError, 'Active must respond to .to_a()') unless active.respond_to?(:to_a)
+    raise(ArgumentError, 'Active must respond to .append()') unless active.respond_to?(:append)
+    raise(ArgumentError, 'Active must respond to .clear()') unless active.respond_to?(:clear)
+    active
+  end
+
+  def to_txn(txn)
+    raise(ArgumentError, 'Transaction hash can\'t be nil') unless txn
+    raise(ArgumentError, 'Transaction hash must be a String') unless txn.is_a?(String)
+    raise(ArgumentError, 'Invalid format of the transaction hash') unless /^0x[0-9a-fA-F]{64}$/.match?(txn)
+    txn
+  end
+
+  def to_amount(amount)
+    raise(ArgumentError, 'Amount can\'t be nil') unless amount
+    raise(ArgumentError, "Amount (#{amount}) must be an Integer") unless amount.is_a?(Integer)
+    raise(ArgumentError, "Amount (#{amount}) must be a positive Integer") unless amount.positive?
+    raise(ArgumentError, "Amount (#{amount}) must fit into uint256") if amount > MAX_AMOUNT
+    amount
+  end
+
+  def to_limit(limit)
+    raise(ArgumentError, 'Gas limit must be an Integer') unless limit.is_a?(Integer)
+    least = Eth::Tx::DEFAULT_GAS_LIMIT
+    raise(ArgumentError, "Gas limit #{limit} is below #{least}") if limit < least
+    most = Eth::Tx::BLOCK_GAS_LIMIT
+    raise(ArgumentError, "Gas limit #{limit} is above #{most}") if limit > most
+    limit
+  end
+
+  def to_price(price)
+    raise(ArgumentError, 'Gas price can\'t be nil') unless price
+    raise(ArgumentError, 'Gas price must be an Integer') unless price.is_a?(Integer)
+    raise(ArgumentError, 'Gas price must be a positive Integer') unless price.positive?
+    price
+  end
+
+  def to_delay(delay)
+    raise(ArgumentError, 'Delay must be a number') unless delay.is_a?(Numeric)
+    raise(ArgumentError, 'Delay must be a positive number') unless delay.positive?
+    delay
+  end
+
+  def to_subscription(id)
+    raise(ArgumentError, 'Subscription ID must be an Integer') unless id.is_a?(Integer)
+    raise(ArgumentError, 'Subscription ID must be a positive Integer') unless id.positive?
+    id
+  end
+end

--- a/lib/erc20/fake_wallet.rb
+++ b/lib/erc20/fake_wallet.rb
@@ -3,15 +3,22 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
+require_relative 'checks'
 require_relative 'erc20'
 require_relative 'wallet'
 
 # A fake wallet that behaves like a +ERC20::Wallet+.
 #
+# It rejects exactly what the real wallet rejects, so that a broken private
+# key, address, or amount fails in a test the same way it would fail with a
+# real provider, where money is at stake.
+#
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
 # Copyright:: Copyright (c) 2025 Yegor Bugayenko
 # License:: MIT
 class ERC20::FakeWallet
+  include ERC20::Checks
+
   TXN_HASH = '0x172de9cda30537eae68ab4a96163ebbb8f8a85293b8737dd2e5deb4714b14623'
 
   attr_reader :host, :port, :ssl, :chain, :contract, :ws_path, :http_path, :history
@@ -49,6 +56,7 @@ class ERC20::FakeWallet
   # @param [String] address Public key, in hex, starting from '0x'
   # @return [Integer] Balance, in tokens
   def balance(address)
+    to_address(address)
     b = @balances[address] || 42_000_000
     @history << { method: :balance, address:, result: b }
     b
@@ -59,6 +67,7 @@ class ERC20::FakeWallet
   # @param [String] address Public key, in hex, starting from '0x'
   # @return [Integer] Balance, in tokens
   def eth_balance(address)
+    to_address(address)
     b = @eth_balances[address] || 77_000_000_000_000_000
     @history << { method: :eth_balance, address:, result: b }
     b
@@ -70,6 +79,8 @@ class ERC20::FakeWallet
   # @param [String] to Public key of the receiver, in hex, starting from '0x'
   # @return [Integer] Amount, in ERC20 tokens
   def sum_of(txn, to: nil)
+    to_txn(txn)
+    to_address(to) unless to.nil?
     tokens = 42_000_000
     @history << { method: :sum_of, txn:, to:, result: tokens }
     tokens
@@ -82,17 +93,25 @@ class ERC20::FakeWallet
   # @param [Integer] amount How many ERC20 tokens to send
   # @return [Integer] How many gas units required
   def gas_estimate(from, to, amount)
+    to_address(from)
+    to_address(to)
+    to_amount(amount)
     gas = 66_000
     @history << { method: :gas_estimate, from:, to:, amount:, result: gas }
     gas
   end
 
-  # What is the price of gas unit in gwei?
-  # @return [Integer] Price of gas unit, in gwei (0.000000001 ETH)
+  # What is the price of gas unit in wei?
+  #
+  # The unit is the same as in +ERC20::Wallet#gas_price+: a price in gwei
+  # would be a billion times smaller and would make every fee computed in a
+  # test look affordable, while in production it wouldn't be.
+  #
+  # @return [Integer] Price of gas unit, in wei (1 gwei = 0.000000001 ETH)
   def gas_price
-    gwei = 55_555
-    @history << { method: :gas_price, result: gwei }
-    gwei
+    wei = 55_555_000_000
+    @history << { method: :gas_price, result: wei }
+    wei
   end
 
   # Send a single ERC20 payment from a private address to a public one.
@@ -101,9 +120,14 @@ class ERC20::FakeWallet
   # @param [String] address Public key, in hex
   # @param [Integer] amount The amount of ERC20 tokens to send
   # @param [Integer] limit Optional gas limit
-  # @param [Integer] price Optional gas price in gwei
+  # @param [Integer] price The most you pay per computation unit, in wei
   # @return [String] Transaction hash
-  def pay(priv, address, amount, limit: nil, price: nil)
+  def pay(priv, address, amount, limit: nil, price: gas_price)
+    to_priv(priv)
+    to_address(address)
+    to_amount(amount)
+    to_limit(limit) if limit
+    to_price(price)
     hex = TXN_HASH
     @history << { method: :pay, priv:, address:, amount:, limit:, price:, result: hex }
     hex
@@ -114,9 +138,13 @@ class ERC20::FakeWallet
   # @param [String] priv Private key, in hex
   # @param [String] address Public key, in hex
   # @param [Integer] amount The amount of ETHs to send
-  # @param [Integer] price Optional gas price in gwei
+  # @param [Integer] price The most you pay per computation unit, in wei
   # @return [String] Transaction hash
-  def eth_pay(priv, address, amount, price: nil)
+  def eth_pay(priv, address, amount, price: gas_price)
+    to_priv(priv)
+    to_address(address)
+    to_amount(amount)
+    to_price(price)
     hex = TXN_HASH
     @history << { method: :eth_pay, priv:, address:, amount:, price:, result: hex }
     hex
@@ -127,12 +155,18 @@ class ERC20::FakeWallet
   # @param [Array<String>] addresses Addresses to monitor
   # @param [Array] active List of addresses that we are actually listening to
   # @param [Boolean] raw TRUE if you need to get JSON events as they arrive from Websockets
-  # @param [Integer] delay How many seconds to wait between +eth_subscribe+ calls
-  def accept(addresses, active = [], raw: false, delay: 1)
-    @history << { method: :accept, addresses:, active:, raw:, delay: }
+  # @param [Numeric] delay How many seconds to wait between +eth_subscribe+ calls
+  # @param [Integer] subscription_id Unique ID of the subscription
+  def accept(addresses, active = [], raw: false, delay: 1, subscription_id: rand(1..99_999))
+    to_addresses(addresses)
+    to_active(active)
+    to_delay(delay)
+    to_subscription(subscription_id)
+    @history << { method: :accept, addresses:, active:, raw:, delay:, subscription_id: }
     addresses.to_a.each { |a| active.append(a) }
     loop do
       sleep(delay)
+      to_addresses(addresses)
       a = addresses.to_a.sample
       next if a.nil?
       yield(

--- a/lib/erc20/wallet.rb
+++ b/lib/erc20/wallet.rb
@@ -11,6 +11,7 @@ require 'json'
 require 'jsonrpc/client'
 require 'loog'
 require 'uri'
+require_relative 'checks'
 require_relative 'erc20'
 
 # A wallet with ERC20 tokens on Ethereum.
@@ -58,11 +59,10 @@ require_relative 'erc20'
 # Copyright:: Copyright (c) 2025 Yegor Bugayenko
 # License:: MIT
 class ERC20::Wallet
+  include ERC20::Checks
+
   USDT = '0xdac17f958d2ee523a2206206994597c13d831ec7'
   TRANSFER = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
-
-  MAX_AMOUNT = (2**256) - 1
-  private_constant :MAX_AMOUNT
 
   attr_reader :host, :port, :ssl, :chain, :contract, :ws_path, :http_path
 
@@ -137,9 +137,7 @@ class ERC20::Wallet
   # @param [String] address Public key, in hex, starting from '0x'
   # @return [Integer] Balance, in tokens
   def balance(address)
-    raise(ArgumentError, 'Address can\'t be nil') unless address
-    raise(ArgumentError, 'Address must be a String') unless address.is_a?(String)
-    raise(ArgumentError, 'Invalid format of the address') unless /^0x[0-9a-fA-F]{40}$/.match?(address)
+    to_address(address)
     data = "0x70a08231000000000000000000000000#{address[2..].downcase}"
     hex = with_jsonrpc { |jr| jr.eth_call({ to: @contract, data: data }, 'latest') }
     unless /^0x[0-9a-fA-F]{64}$/.match?(hex)
@@ -162,9 +160,7 @@ class ERC20::Wallet
   # @param [String] address Public key, in hex, starting from '0x'
   # @return [Integer] Balance, in ETH
   def eth_balance(address)
-    raise(ArgumentError, 'Address can\'t be nil') unless address
-    raise(ArgumentError, 'Address must be a String') unless address.is_a?(String)
-    raise(ArgumentError, 'Invalid format of the address') unless /^0x[0-9a-fA-F]{40}$/.match?(address)
+    to_address(address)
     hex = with_jsonrpc { |jr| jr.eth_getBalance(address, 'latest') }
     unless /^0x[0-9a-fA-F]+$/.match?(hex)
       raise(StandardError, "The node answered #{hex.inspect} instead of a hex quantity, for the balance of #{address}")
@@ -186,13 +182,8 @@ class ERC20::Wallet
   # @param [String] to Public key of the receiver, in hex, starting from '0x'
   # @return [Integer] Amount, in ERC20 tokens
   def sum_of(txn, to: nil)
-    raise(ArgumentError, 'Transaction hash can\'t be nil') unless txn
-    raise(ArgumentError, 'Transaction hash must be a String') unless txn.is_a?(String)
-    raise(ArgumentError, 'Invalid format of the transaction hash') unless /^0x[0-9a-fA-F]{64}$/.match?(txn)
-    unless to.nil?
-      raise(ArgumentError, 'Address must be a String') unless to.is_a?(String)
-      raise(ArgumentError, 'Invalid format of the address') unless /^0x[0-9a-fA-F]{40}$/.match?(to)
-    end
+    to_txn(txn)
+    to_address(to) unless to.nil?
     receipt =
       with_jsonrpc do |jr|
         jr.eth_getTransactionReceipt(txn)
@@ -226,16 +217,9 @@ class ERC20::Wallet
   # @param [Integer] amount How many ERC20 tokens to send
   # @return [Integer] Number of gas units required
   def gas_estimate(from, to, amount)
-    raise(ArgumentError, 'Address can\'t be nil') unless from
-    raise(ArgumentError, 'Address must be a String') unless from.is_a?(String)
-    raise(ArgumentError, 'Invalid format of the address') unless /^0x[0-9a-fA-F]{40}$/.match?(from)
-    raise(ArgumentError, 'Address can\'t be nil') unless to
-    raise(ArgumentError, 'Address must be a String') unless to.is_a?(String)
-    raise(ArgumentError, 'Invalid format of the address') unless /^0x[0-9a-fA-F]{40}$/.match?(to)
-    raise(ArgumentError, 'Amount can\'t be nil') unless amount
-    raise(ArgumentError, "Amount (#{amount}) must be an Integer") unless amount.is_a?(Integer)
-    raise(ArgumentError, "Amount (#{amount}) must be a positive Integer") unless amount.positive?
-    raise(ArgumentError, "Amount (#{amount}) must fit into uint256") if amount > MAX_AMOUNT
+    to_address(from)
+    to_address(to)
+    to_amount(amount)
     gas =
       with_jsonrpc do |jr|
         jr.eth_estimateGas({ from:, to: @contract, data: to_pay_data(to, amount) }, 'latest').to_i(16)
@@ -307,24 +291,11 @@ class ERC20::Wallet
   # @param [Integer] price The most you pay per computation unit
   # @return [String] Transaction hash
   def pay(priv, address, amount, limit: nil, price: gas_price)
-    raise(ArgumentError, 'Private key can\'t be nil') unless priv
-    raise(ArgumentError, 'Private key must be a String') unless priv.is_a?(String)
-    raise(ArgumentError, 'Invalid format of private key') unless /^[0-9a-fA-F]{64}$/.match?(priv)
-    raise(ArgumentError, 'Address can\'t be nil') unless address
-    raise(ArgumentError, 'Address must be a String') unless address.is_a?(String)
-    raise(ArgumentError, 'Invalid format of the address') unless /^0x[0-9a-fA-F]{40}$/.match?(address)
-    raise(ArgumentError, 'Amount can\'t be nil') unless amount
-    raise(ArgumentError, "Amount (#{amount}) must be an Integer") unless amount.is_a?(Integer)
-    raise(ArgumentError, "Amount (#{amount}) must be a positive Integer") unless amount.positive?
-    raise(ArgumentError, "Amount (#{amount}) must fit into uint256") if amount > MAX_AMOUNT
-    if limit
-      raise(ArgumentError, 'Gas limit must be an Integer') unless limit.is_a?(Integer)
-      raise(ArgumentError, "Gas limit #{limit} is below #{Eth::Tx::DEFAULT_GAS_LIMIT}") if limit < Eth::Tx::DEFAULT_GAS_LIMIT
-      raise(ArgumentError, "Gas limit #{limit} is above #{Eth::Tx::BLOCK_GAS_LIMIT}") if limit > Eth::Tx::BLOCK_GAS_LIMIT
-    end
-    raise(ArgumentError, 'Gas price can\'t be nil') unless price
-    raise(ArgumentError, 'Gas price must be an Integer') unless price.is_a?(Integer)
-    raise(ArgumentError, 'Gas price must be a positive Integer') unless price.positive?
+    to_priv(priv)
+    to_address(address)
+    to_amount(amount)
+    to_limit(limit) if limit
+    to_price(price)
     key = Eth::Key.new(priv: priv)
     from = key.address.to_s
     tnx =
@@ -358,18 +329,10 @@ class ERC20::Wallet
   # @param [Integer] price The most you pay per computation unit
   # @return [String] Transaction hash
   def eth_pay(priv, address, amount, price: gas_price)
-    raise(ArgumentError, 'Private key can\'t be nil') unless priv
-    raise(ArgumentError, 'Private key must be a String') unless priv.is_a?(String)
-    raise(ArgumentError, 'Invalid format of private key') unless /^[0-9a-fA-F]{64}$/.match?(priv)
-    raise(ArgumentError, 'Address can\'t be nil') unless address
-    raise(ArgumentError, 'Address must be a String') unless address.is_a?(String)
-    raise(ArgumentError, 'Invalid format of the address') unless /^0x[0-9a-fA-F]{40}$/.match?(address)
-    raise(ArgumentError, 'Amount can\'t be nil') unless amount
-    raise(ArgumentError, "Amount (#{amount}) must be an Integer") unless amount.is_a?(Integer)
-    raise(ArgumentError, "Amount (#{amount}) must be a positive Integer") unless amount.positive?
-    raise(ArgumentError, 'Gas price can\'t be nil') unless price
-    raise(ArgumentError, 'Gas price must be an Integer') unless price.is_a?(Integer)
-    raise(ArgumentError, 'Gas price must be a positive Integer') unless price.positive?
+    to_priv(priv)
+    to_address(address)
+    to_amount(amount)
+    to_price(price)
     key = Eth::Key.new(priv: priv)
     from = key.address.to_s
     tnx =
@@ -448,17 +411,10 @@ class ERC20::Wallet
   # @param [Numeric] delay How many seconds to wait between +eth_subscribe+ calls
   # @param [Integer] subscription_id Unique ID of the subscription
   def accept(addresses, active = [], raw: false, delay: 1, subscription_id: rand(1..99_999), &)
-    raise(ArgumentError, 'Addresses can\'t be nil') unless addresses
-    raise(ArgumentError, 'Addresses must respond to .to_a()') unless addresses.respond_to?(:to_a)
     to_addresses(addresses)
-    raise(ArgumentError, 'Active can\'t be nil') unless active
-    raise(ArgumentError, 'Active must respond to .to_a()') unless active.respond_to?(:to_a)
-    raise(ArgumentError, 'Active must respond to .append()') unless active.respond_to?(:append)
-    raise(ArgumentError, 'Active must respond to .clear()') unless active.respond_to?(:clear)
-    raise(ArgumentError, 'Delay must be a number') unless delay.is_a?(Numeric)
-    raise(ArgumentError, 'Delay must be a positive number') unless delay.positive?
-    raise(ArgumentError, 'Subscription ID must be an Integer') unless subscription_id.is_a?(Integer)
-    raise(ArgumentError, 'Subscription ID must be a positive Integer') unless subscription_id.positive?
+    to_active(active)
+    to_delay(delay)
+    to_subscription(subscription_id)
     EventMachine.run do
       reaccept(addresses, active, raw:, delay:, subscription_id:, &)
     end
@@ -582,13 +538,6 @@ class ERC20::Wallet
           log_it(:debug, "Failed ##{subscription_id} at #{log_url}: #{e.message}")
         end
       end
-    end
-  end
-
-  def to_addresses(addresses)
-    addresses.to_a.each do |a|
-      raise(ArgumentError, 'Each address must be a String') unless a.is_a?(String)
-      raise(ArgumentError, "Invalid format of the address (#{a})") unless /^0x[0-9a-fA-F]{40}$/.match?(a)
     end
   end
 

--- a/test/erc20/test_fake_wallet.rb
+++ b/test/erc20/test_fake_wallet.rb
@@ -83,21 +83,104 @@ class TestFakeWallet < ERC20::Test
     address = '0xfadef8ba4a5d709a2bf55b7a8798c9b438c640c1'
     w = ERC20::FakeWallet.new
     amount = 555_000
-    txn = w.pay(priv, address, amount, limit: 999, price: 777)
+    txn = w.pay(priv, address, amount, limit: 66_000, price: 777)
     assert_equal(66, txn.length)
     assert_match(/^0x[a-f0-9]{64}$/, txn)
     assert_equal(ERC20::FakeWallet::TXN_HASH, txn)
-    assert_includes(w.history, { method: :pay, result: txn, priv:, address:, amount:, limit: 999, price: 777 })
+    assert_includes(w.history, { method: :pay, result: txn, priv:, address:, amount:, limit: 66_000, price: 777 })
   end
 
   def test_pays_fake_eths
     txn = ERC20::FakeWallet.new.eth_pay(
-      Eth::Key.new(priv: '81a9b2114d53731ecc84b261ef6c0387dde34d5907fe7b441240cc21d61bf80a'),
+      '81a9b2114d53731ecc84b261ef6c0387dde34d5907fe7b441240cc21d61bf80a',
       '0xfadef8ba4a5d709a2bf55b7a8798c9b438c640c1',
       555
     )
     assert_equal(66, txn.length)
     assert_match(/^0x[a-f0-9]{64}$/, txn)
+  end
+
+  def test_returns_gas_price_in_wei
+    assert_operator(
+      ERC20::FakeWallet.new.gas_price, :>=, ERC20::Wallet::GAS_PRICE_TIP,
+      'A price in wei cannot be below the tip that the real wallet always adds'
+    )
+  end
+
+  def test_rejects_a_malformed_address
+    assert_match(
+      /Invalid format of the address/,
+      assert_raises(ArgumentError) { ERC20::FakeWallet.new.balance('garbage') }.message,
+      'A malformed address cannot have a balance, the real wallet never reports one'
+    )
+  end
+
+  def test_rejects_a_negative_amount
+    assert_match(
+      /must be a positive Integer/,
+      assert_raises(ArgumentError) do
+        ERC20::FakeWallet.new.pay(
+          '81a9b2114d53731ecc84b261ef6c0387dde34d5907fe7b441240cc21d61bf80a',
+          '0xfadef8ba4a5d709a2bf55b7a8798c9b438c640c1', -5
+        )
+      end.message,
+      'A negative payment cannot be recorded as if it were sent'
+    )
+  end
+
+  def test_rejects_a_nil_private_key
+    assert_match(
+      /Private key can't be nil/,
+      assert_raises(ArgumentError) do
+        ERC20::FakeWallet.new.eth_pay(nil, '0xfadef8ba4a5d709a2bf55b7a8798c9b438c640c1', 5)
+      end.message,
+      'A payment without a private key cannot look successful'
+    )
+  end
+
+  def test_complains_like_the_real_wallet
+    assert_equal(
+      assert_raises(ArgumentError) do
+        ERC20::Wallet.new(host: 'example.com', log: Loog::NULL).balance('0xdead')
+      end.message,
+      assert_raises(ArgumentError) { ERC20::FakeWallet.new.balance('0xdead') }.message,
+      'The fake wallet cannot complain about a broken address in its own words'
+    )
+  end
+
+  def test_accepts_a_subscription_id
+    crashes = []
+    daemon =
+      Thread.new do
+        ERC20::FakeWallet.new.accept(
+          Primitivo.new(['0xfadef8ba4a5d709a2bf55b7a8798c9b438c640c1']), Primitivo.new([]),
+          delay: 0.1, subscription_id: 42
+        ) { |_| nil }
+      rescue StandardError => e
+        crashes.append(e.message)
+      end
+    daemon.join(1)
+    daemon.kill
+    assert_empty(crashes, 'The subscription ID that the real wallet takes cannot be refused by the fake one')
+  end
+
+  def test_rejects_a_broken_address_at_runtime
+    addresses = Primitivo.new(['0xfadef8ba4a5d709a2bf55b7a8798c9b438c640c1'])
+    crashes = []
+    daemon =
+      Thread.new do
+        ERC20::FakeWallet.new.accept(addresses, Primitivo.new([]), delay: 0.1) { |_| nil }
+      rescue StandardError => e
+        crashes.append(e.message)
+      end
+    addresses.append('garbage')
+    wait_for(10) { !crashes.empty? }
+    daemon.kill
+    daemon.join(30)
+    assert_match(
+      /Invalid format of the address/, crashes.first,
+      'An address that arrives later cannot be monitored silently'
+    )
   end
 
   def test_accepts_payments_on_hardhat


### PR DESCRIPTION
`FakeWallet` now takes the `subscription_id` that `Wallet#accept` takes, returns wei from `gas_price` instead of gwei, and rejects what the real wallet rejects. The checks moved into one new module, `ERC20::Checks`, which both wallets include, so a private key, an address, an amount, a gas limit and a price are validated in a single place. `Wallet` lost some sixty lines that way.

Two tests in this repo passed only because the fake checked nothing: one paid with an `Eth::Key` object where a hex string is required, another with a gas limit of 999, below the 21000 minimum. The dollar scenario of `dry.feature` was worse — the shell ate its `$10`, the CLI received `0`, and the fake recorded a zero-token payment as if it were sent. The `$` is escaped now, so the scenario finally pays ten dollars.

Three judgement calls worth a look. The fake's `pay` and `eth_pay` default `price:` to `gas_price` like the real ones do, since a nil price is no longer allowed, which adds a `gas_price` entry to `history` when the caller passes no price. `Wallet#eth_pay` now caps the amount at uint256, which `pay` and `gas_estimate` always did. And the fake re-checks the addresses on every iteration of its loop, so an address that arrives later fails there too, the way it does in the real wallet.

Item 4 of the issue is already done: 1ac09b7 taught `sum_of` to record its history while fixing #147. Two related one-liners I left alone — `bin/erc20` help still calls the gas price "in gwei", and the README's `FakeWallet` example asserts a `history` hash that has never matched, since the entries carry `limit`, `price` and `result` too. Say the word and I file issues for them.

Closes #157