### PR TITLE
Make test_checks_eth_balance check eth_balance

### DIFF
--- a/test/erc20/test_wallet_hardhat.rb
+++ b/test/erc20/test_wallet_hardhat.rb
@@ -49,7 +49,10 @@ class TestWalletHardhat < ERC20::Test
   def test_checks_eth_balance
     WebMock.enable_net_connect!
     on_hardhat do |wallet|
-      assert_equal(456_000_000_000, wallet.balance(Eth::Key.new(priv: WALTER).address.to_s))
+      assert_equal(
+        66_666_666_666_666_666_666_666, wallet.eth_balance(Eth::Key.new(priv: WALTER).address.to_s),
+        'The ETH balance that hardhat gave to Walter cannot be read as a different number'
+      )
     end
   end
 


### PR DESCRIPTION
`test_checks_eth_balance` called `wallet.balance`, not `wallet.eth_balance`. It
was a copy of `test_checks_balance` pointed at Walter instead of Jeff, so on
hardhat nothing ever asserted a known ETH amount — `eth_balance` was only
exercised indirectly, through the before-and-after arithmetic of `test_eth_pays`
and its thread variant, which would still pass if the decoding were off by a
constant.

Now it reads Walter's balance and expects the 66666666666666666666666 wei that
`hardhat.config.js` gives him. That number goes through the same
`hex[2..].to_i(16)` path as the token balance, and being a 23-digit bignum it
is a better probe of it than any small amount would be.

One thing the reviewer loses: the old assertion was the only place that checked
Walter's 456000000000 tokens from `Foo.sol`. Jeff's mint is still checked by
`test_checks_balance`, and Walter's tokens are still moved around by `test_pays`,
so I did not add a third balance test just to keep that number covered — say the
word if you would rather have one.

Verified against hardhat: the whole file is 16 tests, 126 assertions, green in
168s, and the node log shows `eth_getBalance` where it used to show a contract
call.

Closes #158